### PR TITLE
Bug in locate along

### DIFF
--- a/src/test/java/org/geolatte/geom/LocateAlongTest.java
+++ b/src/test/java/org/geolatte/geom/LocateAlongTest.java
@@ -1,7 +1,34 @@
 package org.geolatte.geom;
 
-/**
- *
- */
+import junit.framework.Assert;
+import org.geolatte.geom.codec.Wkt;
+import org.junit.Test;
+
 public class LocateAlongTest {
+
+    @Test
+    public void locateAlongRightBeforeEnd() {
+        Geometry geom = Wkt.newDecoder().decode("SRID=31370;MULTILINESTRINGM((0 0 0,4000 0 4),(6000 0 6,10000 0 10))");
+
+        Geometry located = geom.locateAlong(3.999);
+        Assert.assertNotNull(located);
+    }
+
+    @Test
+    public void locateAlongAtTheEnd() {
+        // be careful, this one only fails if jvm level assertions are enabled (-ea flag)
+        Geometry geom = Wkt.newDecoder().decode("SRID=31370;MULTILINESTRINGM((0 0 0,4000 0 4),(6000 0 6,10000 0 10))");
+
+        Geometry located = geom.locateAlong(4.0);
+        Assert.assertNotNull(located);
+    }
+
+    @Test
+    public void locateAlongAtTheEndOnlyOneSegment() {
+        Geometry geom = Wkt.newDecoder().decode("SRID=31370;MULTILINESTRINGM((0 0 0,4000 0 4))");
+
+        Geometry located = geom.locateAlong(4.0);
+        Assert.assertNotNull(located);
+    }
+
 }


### PR DESCRIPTION
test for failing Geometry.locateAlong (only when jvm assertions are enabled)
