### PR TITLE
add failing test to show that wkt en/decoding is not idempotent

### DIFF
--- a/src/test/java/org/geolatte/geom/codec/TestWkbDecodingIdempotent.java
+++ b/src/test/java/org/geolatte/geom/codec/TestWkbDecodingIdempotent.java
@@ -1,0 +1,26 @@
+package org.geolatte.geom.codec;
+
+import org.geolatte.geom.*;
+import org.geolatte.geom.crs.CrsId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class TestWkbDecodingIdempotent {
+
+    @Test
+    public void testWkbConversionShouldBeStable() {
+        Geometry original = new Point(PointSequenceBuilders.fixedSized(1, DimensionalFlag.d2D, new CrsId("EPSG", 31370))
+                .add(68878.8400879, 169038.177124).toPointSequence());
+
+        String originalWkb = "01010000208A7A000084020071EDD0F040DBFCBF6A71A20441";
+
+        assertEquals(originalWkb, Wkb.toWkb(original).toString());
+
+        // geom to wkb to geom blijft stabliel
+        assertEquals(Wkb.fromWkb(Wkb.toWkb(original)),original);
+    }
+}

--- a/src/test/java/org/geolatte/geom/codec/TestWktDecodingIdempotent.java
+++ b/src/test/java/org/geolatte/geom/codec/TestWktDecodingIdempotent.java
@@ -21,11 +21,7 @@ public class TestWktDecodingIdempotent {
         String originalWkt = "SRID=31370;POINT(68878.8400879 169038.177124)";
         assertEquals(originalWkt, Wkt.toWkt(original));
 
-
-        Geometry geomFromOriginalWkt = Wkt.fromWkt(originalWkt);
-
-        assertEquals(original,geomFromOriginalWkt);
+        // geom to wkb to geom zou stabiel moeten blijven
+        assertEquals(Wkt.fromWkt(Wkt.toWkt(original)),original);
     }
-
-
 }


### PR DESCRIPTION
Wkt en/decoding is niet idempotent en zorgt ervoor dat geometries niet meer equals zijn. Deze pull request is enkel een falende test, geen oplossing :)
