### PR TITLE
Store points in Oracle as SDO_POINT_TYPE instead of arrays of points.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>geolatte-geom</artifactId>
     <name>geolatte-geom</name>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <description>
         This geoLatte-geom library offers a geometry model that conforms to the OGC Simple Features for SQL
         specification.

--- a/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
+++ b/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
@@ -88,8 +88,18 @@ public class NumericalMethods {
         if (positions.size() < 3) return true;
         Position p0 = positions.getPositionN(0);
         Position p1 = positions.getPositionN(1);
-        Position p2 = positions.getPositionN(2);
-        return isCounterClockwise(p0, p1, p2);
+        double det = 0;
+        int positionsSize = positions.size();
+        int i = 2;
+        while(i < positionsSize && det == 0) {
+            Position p2 = positions.getPositionN(i);
+            det = deltaDeterminant(p0, p1, p2);
+            i++;
+        }
+        if (det == 0) {
+            throw new IllegalArgumentException("Positions are collinear in 2D");
+        }
+        return det > 0;
     }
 
     public static boolean collinear(Position p0, Position p1, Position p2) {

--- a/src/main/java/org/geolatte/geom/codec/db/oracle/OracleJDBCTypeFactory.java
+++ b/src/main/java/org/geolatte/geom/codec/db/oracle/OracleJDBCTypeFactory.java
@@ -44,6 +44,7 @@ public class OracleJDBCTypeFactory implements SQLTypeFactory {
 	private final Method structDescriptorCreator;
 	private final Method arrayDescriptorCreator;
 	private final Constructor<?> numberConstructor;
+	private final Constructor<?> doubleConstructor;
 	private final Constructor<?> arrayConstructor;
 	private final Constructor<?> structConstructor;
 	private final ConnectionFinder connectionFinder;
@@ -68,6 +69,7 @@ public class OracleJDBCTypeFactory implements SQLTypeFactory {
 		Class<?> structClass = findClass( "oracle.sql.STRUCT" );
 
 		numberConstructor = findConstructor( numberClass, java.lang.Integer.TYPE );
+		doubleConstructor = findConstructor( numberClass, java.lang.Double.TYPE );
 		arrayConstructor = findConstructor( arrayClass, arrayDescriptorClass, Connection.class, Object.class );
 		structConstructor = findConstructor( structClass, structDescriptorClass, Connection.class, Object[].class );
 	}
@@ -112,22 +114,32 @@ public class OracleJDBCTypeFactory implements SQLTypeFactory {
 
 	@Override
 	public Struct createStruct(SDOGeometry geom, Connection conn) throws SQLException {
-		Connection oracleConnection = connectionFinder.find( conn );
+        Connection oracleConnection = connectionFinder.find( conn );
 
 
-		final Object structDescriptor = createStructDescriptor( SDOGeometry.getTypeName(), oracleConnection );
-		final Object[] attributes = createDatumArray( 5 );
-		attributes[0] = createNumber( geom.getGType().intValue() );
-		if ( geom.getSRID() > 0 ) {
-			attributes[1] = createNumber( geom.getSRID() );
-		}
-		else {
-			attributes[1] = null;
-		}
-		attributes[3] = createElemInfoArray( geom.getInfo(), oracleConnection );
-		attributes[4] = createOrdinatesArray( geom.getOrdinates(), oracleConnection );
-		return createStruct( structDescriptor, oracleConnection, attributes );
-	}
+        final Object structDescriptor = createStructDescriptor( SDOGeometry.getTypeName(), oracleConnection );
+        final Object[] attributes = createDatumArray( 5 );
+        attributes[0] = createNumber( geom.getGType().intValue() );
+        if ( geom.getSRID() > 0 ) {
+            attributes[1] = createNumber( geom.getSRID() );
+        }
+        else {
+            attributes[1] = null;
+        }
+        if (geom.getGType().getTypeGeometry().name().equals(TypeGeometry.POINT.name())) {
+            final Object pointStructDescriptor = createStructDescriptor( SDOGeometry.getPointTypeName(), oracleConnection );
+            final Object[] pointAttributes = createDatumArray(3);
+            Double[] ordinateArray = geom.getOrdinates().getOrdinateArray();
+            pointAttributes[0] = createNumber(ordinateArray[0]);
+            pointAttributes[1] = createNumber(ordinateArray[1]);
+            attributes[2] = createStruct(pointStructDescriptor, oracleConnection, pointAttributes);
+            
+        } else {
+            attributes[3] = createElemInfoArray( geom.getInfo(), oracleConnection );
+            attributes[4] = createOrdinatesArray( geom.getOrdinates(), oracleConnection );
+        }
+        return createStruct( structDescriptor, oracleConnection, attributes );
+    }
 
 	@Override
 	public Array createElemInfoArray(ElemInfo elemInfo, Connection conn) {
@@ -215,5 +227,20 @@ public class OracleJDBCTypeFactory implements SQLTypeFactory {
 			throw new RuntimeException( "Error creating oracle NUMBER", e );
 		}
 	}
+	
+	private Object createNumber(Double obj) {
+        try {
+            return doubleConstructor.newInstance( obj );
+        }
+        catch ( InvocationTargetException e ) {
+            throw new RuntimeException( "Error creating oracle NUMBER", e );
+        }
+        catch ( InstantiationException e ) {
+            throw new RuntimeException( "Error creating oracle NUMBER", e );
+        }
+        catch ( IllegalAccessException e ) {
+            throw new RuntimeException( "Error creating oracle NUMBER", e );
+        }
+    }
 
 }

--- a/src/main/java/org/geolatte/geom/codec/db/oracle/SDOGeometry.java
+++ b/src/main/java/org/geolatte/geom/codec/db/oracle/SDOGeometry.java
@@ -35,6 +35,7 @@ import java.util.List;
 public class SDOGeometry {
 
 	private static final String SQL_TYPE_NAME = "MDSYS.SDO_GEOMETRY";
+	private static final String SQL_POINT_TYPE_NAME = "MDSYS.SDO_POINT_TYPE";
 	final private SDOGType gtype;
 	final private int srid;
 	final private SDOPoint point;
@@ -57,6 +58,10 @@ public class SDOGeometry {
 	public static String getTypeName() {
 		return SQL_TYPE_NAME;
 	}
+	
+	public static String getPointTypeName() {
+        return SQL_POINT_TYPE_NAME;
+    }
 
 	static String arrayToString(Object array) {
 		if ( array == null || java.lang.reflect.Array.getLength( array ) == 0 ) {


### PR DESCRIPTION
Hi there, first of all, apologies in case I don't follow your procedures, as I'm new in this project. 
Our use case is that we use Hibernate-spatial to store and query millions of points in Oracle that will be shown on a map. 
I saw in `OracleJDBCTypeFactory`that the `createStruct`will store points as array of points (`SDO_ORDINATE_ARRAY`) instead of actual points (`SDO_POINT_TYPE`) which is not that performant. 
My current pull request suggests that we could use `SDO_POINT_TYPE`. 
I understand that maybe this is something that was already discussed in this project so I'm open to any kind of comments. 
Thanks for your time. 
