### PR TITLE
Fix for Issue #51

### DIFF
--- a/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
+++ b/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
@@ -1,5 +1,8 @@
 package org.geolatte.geom.cga;
 
+import java.util.stream.IntStream;
+
+import org.geolatte.geom.LinearRing;
 import org.geolatte.geom.Position;
 import org.geolatte.geom.PositionSequence;
 
@@ -101,6 +104,33 @@ public class NumericalMethods {
         }
         return det > 0;
     }
+
+    /**
+     * Determines whether the specified {@code LinearRing} is counter-clockwise.
+     *
+     * <p> Orientation is determined by calculating the signed area of the given ring
+     * and using the sign to determine the orientation
+     * <p>The specified Ring is assumed to be valid.
+     *
+     * @param ring a {@code LinearRing}
+     * @return true if the positions of the ring describe it counter-clockwise
+     */
+    public static boolean isCounterClockwise(LinearRing<?> ring) {
+        return IntStream.range(1, ring.getNumPositions()).parallel().boxed().
+                map(idx -> shoelaceStep(idx, ring)).
+                reduce((a, b) -> a + b).
+                filter(orientation -> orientation != 0).
+                orElseThrow(() -> new IllegalArgumentException("Ring is collinear in 2D"))
+                > 0;
+    }
+
+    private static double shoelaceStep(Integer idx, LinearRing<?> ring) {
+        double[] c0 = ring.getPositionN(idx - 1).toArray(null);
+        double[] c1 = ring.getPositionN(idx).toArray(null);
+        double weightedOrientation = determinant(c0[0], c0[1], c1[0], c1[1]);
+        return weightedOrientation;
+    }
+
 
     public static boolean collinear(Position p0, Position p1, Position p2) {
         double det = deltaDeterminant(p0, p1, p2);

--- a/src/main/java/org/geolatte/geom/codec/db/oracle/AbstractSDOEncoder.java
+++ b/src/main/java/org/geolatte/geom/codec/db/oracle/AbstractSDOEncoder.java
@@ -1,13 +1,19 @@
 package org.geolatte.geom.codec.db.oracle;
 
-
-import org.geolatte.geom.*;
-import org.geolatte.geom.codec.db.Encoder;
+import static org.geolatte.geom.PositionSequenceBuilders.fixedSized;
+import static org.geolatte.geom.cga.NumericalMethods.isCounterClockwise;
 
 import java.util.Stack;
 
-import static org.geolatte.geom.PositionSequenceBuilders.fixedSized;
-import static org.geolatte.geom.cga.NumericalMethods.isCounterClockwise;
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.LLAPositionVisitor;
+import org.geolatte.geom.LinearRing;
+import org.geolatte.geom.Measured;
+import org.geolatte.geom.Polygon;
+import org.geolatte.geom.Position;
+import org.geolatte.geom.PositionSequence;
+import org.geolatte.geom.PositionSequenceBuilder;
+import org.geolatte.geom.codec.db.Encoder;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 01/04/15.
@@ -40,14 +46,16 @@ abstract public class AbstractSDOEncoder implements Encoder<SDOGeometry> {
             PositionSequence<?> positionSequence;
             if (i == 0) {
                 et = ElementType.EXTERIOR_RING_STRAIGHT_SEGMENTS;
-                positionSequence = polygon.getExteriorRing().getPositions();
-                if (!isCounterClockwise(positionSequence)) {
+                LinearRing<?> exteriorRing = polygon.getExteriorRing();
+                positionSequence = exteriorRing.getPositions();
+                if (!isCounterClockwise(exteriorRing)) {
                     positionSequence = reverse(positionSequence);
                 }
             } else {
                 et = ElementType.INTERIOR_RING_STRAIGHT_SEGMENTS;
-                positionSequence = polygon.getInteriorRingN(i - 1).getPositions();
-                if (isCounterClockwise(positionSequence)) {
+                LinearRing<?> interiorRing = polygon.getInteriorRingN(i - 1);
+                positionSequence = interiorRing.getPositions();
+                if (isCounterClockwise(interiorRing)) {
                     positionSequence = reverse(positionSequence);
                 }
             }

--- a/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
+++ b/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
@@ -1,0 +1,125 @@
+package org.geolatte.geom.cga;
+
+import static org.geolatte.geom.builder.DSL.g;
+import static org.geolatte.geom.builder.DSL.ring;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedList;
+
+import org.geolatte.geom.G2D;
+import org.geolatte.geom.LinearRing;
+import org.geolatte.geom.Position;
+import org.geolatte.geom.crs.CrsRegistry;
+import org.geolatte.geom.crs.GeographicCoordinateReferenceSystem;
+import org.junit.Test;
+
+/**
+ * @author Stephan Psader, GAF AG, 2017
+ */
+public class NumericalMethodsTest {
+    GeographicCoordinateReferenceSystem<G2D> wgs84 =
+            CrsRegistry.getGeographicCoordinateReferenceSystemForEPSG(4326);
+
+    @Test
+    public void testNotCounterClockwiseLinearRing() {
+        //LINEARRING(500 500, 550 500, 600 500, 600 450, 600 400, 550 450, 500 400, 500 450, 500 500)
+        LinkedList<G2D> positions = new LinkedList<>();
+        positions.add(g(500, 500));
+        positions.add(g(550, 500));
+        positions.add(g(600, 500));
+        positions.add(g(600, 450));
+        positions.add(g(600, 400));
+        positions.add(g(550, 450));
+        positions.add(g(500, 400));
+        positions.add(g(500, 450));
+
+        //test orientation once for each position as starting point
+        for (int i = 1; i <= positions.size(); i++) {
+            positions.add(positions.getFirst());
+            G2D[] positionsArray = positions.toArray(new G2D[positions.size()]);
+            positions.removeFirst();
+
+            LinearRing<? extends Position> ring = ring(wgs84, positionsArray);
+
+            assertFalse(NumericalMethods.isCounterClockwise(ring));
+        }
+    }
+
+    @Test
+    public void testNotCounterClockwiseLinearRingWithSpike() {
+        //LINEARRING (500 500, 550 500, 600 500, 540 500, 600 450, 600 400, 600 350, 600 400, 550 450, 500 400, 450 400, 500 400, 500 450, 500 550, 500 500)
+        LinkedList<G2D> positions = new LinkedList<>();
+        positions.add(g(500, 500));
+        positions.add(g(550, 500));
+        positions.add(g(600, 500));
+        positions.add(g(540, 500));
+        positions.add(g(600, 450));
+        positions.add(g(600, 400));
+        positions.add(g(600, 350));
+        positions.add(g(600, 400));
+        positions.add(g(550, 450));
+        positions.add(g(500, 400));
+        positions.add(g(450, 400));
+        positions.add(g(500, 400));
+        positions.add(g(500, 450));
+        positions.add(g(500, 550));
+
+        //test orientation once for each position as starting point
+        for (int i = 1; i <= positions.size(); i++) {
+            positions.add(positions.getFirst());
+            G2D[] positionsArray = positions.toArray(new G2D[positions.size()]);
+            positions.removeFirst();
+
+            LinearRing<? extends Position> ring = ring(wgs84, positionsArray);
+
+            assertFalse(NumericalMethods.isCounterClockwise(ring));
+        }
+    }
+
+    @Test
+    public void testCounterClockwiseLinearRing() {
+        //LINEARRING (500 500, 500 450, 500 400, 550 450, 600 400, 600 450, 600 500, 550 500, 500 500)
+        LinkedList<G2D> positions = new LinkedList<>();
+        positions.add(g(500, 500));
+        positions.add(g(500, 450));
+        positions.add(g(500, 400));
+        positions.add(g(550, 450));
+        positions.add(g(600, 400));
+        positions.add(g(600, 450));
+        positions.add(g(600, 500));
+        positions.add(g(550, 500));
+
+        //test orientation once for each position as starting point
+        for (int i = 1; i <= positions.size(); i++) {
+            positions.add(positions.getFirst());
+            G2D[] positionsArray = positions.toArray(new G2D[positions.size()]);
+            positions.removeFirst();
+
+            LinearRing<? extends Position> ring = ring(wgs84, positionsArray);
+
+            assertTrue(NumericalMethods.isCounterClockwise(ring));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testColinearVertical() {
+        LinearRing<? extends Position> ring =
+                ring(wgs84, g(500, 500), g(500, 400), g(500, 300), g(500, 200), g(500, 500));
+        NumericalMethods.isCounterClockwise(ring);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testColinearHorizontal() {
+        LinearRing<? extends Position> ring =
+                ring(wgs84, g(500, 500), g(400, 500), g(300, 500), g(200, 500), g(500, 500));
+        NumericalMethods.isCounterClockwise(ring);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testColinearZigZag() {
+        LinearRing<? extends Position> ring =
+                ring(wgs84, g(500, 500), g(400, 400), g(300, 600), g(200, 200), g(300, 600), g(400,400), g(500, 500));
+        NumericalMethods.isCounterClockwise(ring);
+    }
+}

--- a/src/test/java/org/geolatte/geom/codec/db/oracle/TestSdoPolygonEncoder.java
+++ b/src/test/java/org/geolatte/geom/codec/db/oracle/TestSdoPolygonEncoder.java
@@ -30,6 +30,22 @@ public class TestSdoPolygonEncoder {
     }
 
     @Test
+    public void test2DPolygonWithHole2() {
+        // changed Polygon of "test2DPolygonWithHole" so orientation of the first 3 vertices,
+        // of the hole in the polygon to be encoded, differs from the orientation of the hole itself
+        // POLYGON ((2 4, 4 3, 10 3, 13 5, 13 9, 11 13, 5 13, 2 11, 2 4), (7 5, 9 6, 10 10, 10 5, 7 5))
+        SDOGeometry expected = SDOGeometryHelper.sdoGeometry(2003, wgs84.getCrsId().getCode(), null,
+                new int[] { 1, 1003, 1, 19, 2003, 1 },
+                new Double[] { 2d, 4d, 4d, 3d, 10d, 3d, 13d, 5d, 13d, 9d, 11d, 13d, 5d, 13d, 2d,
+                        11d, 2d, 4d, 7d, 5d, 9d, 6d, 10d, 10d, 10d, 5d, 7d, 5d });
+        Polygon<G2D> poly = polygon(wgs84,
+                ring(g(2, 4), g(4, 3), g(10, 3), g(13, 5), g(13, 9), g(11, 13), g(5, 13), g(2, 11),
+                        g(2, 4)), ring(g(7, 5), g(9, 6), g(10, 10), g(10, 5), g(7, 5)));
+
+        assertEquals(expected, Encoders.encode(poly));
+    }
+
+    @Test
     public void test2DRectangle() {
 
         SDOGeometry expected = SDOGeometryHelper.sdoGeometry(2003, wgs84.getCrsId().getCode(), null, new int[]{1,
@@ -51,5 +67,20 @@ public class TestSdoPolygonEncoder {
         assertEquals(expected, Encoders.encode(poly));
     }
 
+    @Test
+    public void test2DPolygonWithReversedOrientationRings2() {
+        // changed Polygon of "test2DPolygonWithHole" so orientation of the first 3 vertices,
+        // of the hole in the polygon to be encoded, differs from the orientation of the hole itself
+        // POLYGON ((2 4, 2 11, 5 13, 11 13, 13 9, 13 5, 10 3, 4 3, 2 4), (7 5, 8 9, 10 10, 7 10, 7 5))
+        SDOGeometry expected = SDOGeometryHelper.sdoGeometry(2003, wgs84.getCrsId().getCode(), null,
+                new int[] { 1, 1003, 1, 19, 2003, 1 },
+                new Double[] { 2d, 4d, 4d, 3d, 10d, 3d, 13d, 5d, 13d, 9d, 11d, 13d, 5d, 13d, 2d,
+                        11d, 2d, 4d, 7d, 5d, 7d, 10d, 10d, 10d, 8d, 9d, 7d, 5d });
+        Polygon<G2D> poly = polygon(wgs84,
+                ring(g(2, 4), g(2, 11), g(5, 13), g(11, 13), g(13, 9), g(13, 5), g(10, 3), g(4, 3),
+                        g(2, 4)), ring(g(7, 5), g(8, 9), g(10, 10), g(7, 10), g(7, 5)));
+
+        assertEquals(expected, Encoders.encode(poly));
+    }
 
 }


### PR DESCRIPTION
Implements a method to calculate the orientation of a LinearRing and use it in AbstractSDOEncoder.addPolygon to decide the orientation of the rings of a polygon to be encoded.