### PR TITLE
Add EWKT and EWKB encoders and decoders for SAP HANA.

### DIFF
--- a/src/main/java/org/geolatte/geom/codec/HANAWkbDecoder.java
+++ b/src/main/java/org/geolatte/geom/codec/HANAWkbDecoder.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the GeoLatte project.
+ *
+ *     GeoLatte is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     GeoLatte is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010 - 2017 and Ownership of code is shared by:
+ * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
+ * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
+ */
+package org.geolatte.geom.codec;
+
+import org.geolatte.geom.ByteBuffer;
+import org.geolatte.geom.Position;
+import org.geolatte.geom.crs.CoordinateReferenceSystem;
+
+/**
+ * The HANA EWKB decoder is equivalent to the Postgis EWKB decoder and is there mostly for symmetry reasons.
+ * 
+ * @author Jonathan Bregler, SAP
+ */
+class HANAWkbDecoder extends PostgisWkbDecoder {
+
+	private int currentTypeCode;
+
+	@Override
+	protected <P extends Position> CoordinateReferenceSystem<P> readCrs(ByteBuffer byteBuffer, int typeCode, CoordinateReferenceSystem<P> crs) {
+		boolean hasM = ( this.currentTypeCode & PostgisWkbTypeMasks.M_FLAG ) == PostgisWkbTypeMasks.M_FLAG;
+		boolean hasZ = ( this.currentTypeCode & PostgisWkbTypeMasks.Z_FLAG ) == PostgisWkbTypeMasks.Z_FLAG;
+
+		if ( ( this.currentTypeCode & 0xFFFF ) > 3000 ) {
+			hasM = true;
+			hasZ = true;
+		}
+		else if ( ( this.currentTypeCode & 0xFFFF ) > 2000 ) {
+			hasM = true;
+		}
+		else if ( ( this.currentTypeCode & 0xFFFF ) > 1000 ) {
+			hasZ = true;
+		}
+
+		int modifiedTypeCode = this.currentTypeCode;
+		if ( hasM ) {
+			modifiedTypeCode = modifiedTypeCode | PostgisWkbTypeMasks.M_FLAG;
+		}
+		if ( hasZ ) {
+			modifiedTypeCode = modifiedTypeCode | PostgisWkbTypeMasks.Z_FLAG;
+		}
+		return super.readCrs( byteBuffer, modifiedTypeCode, crs );
+	}
+
+	@Override
+	protected int readTypeCode(ByteBuffer byteBuffer) {
+		this.currentTypeCode = super.readTypeCode( byteBuffer );
+		return (this.currentTypeCode & 0xFFFF) % 100;
+	}
+}

--- a/src/main/java/org/geolatte/geom/codec/HANAWkbEncoder.java
+++ b/src/main/java/org/geolatte/geom/codec/HANAWkbEncoder.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the GeoLatte project.
+ *
+ *     GeoLatte is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     GeoLatte is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010 - 2017 and Ownership of code is shared by:
+ * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
+ * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
+ */
+package org.geolatte.geom.codec;
+
+import static org.geolatte.geom.crs.CoordinateReferenceSystems.hasMeasureAxis;
+import static org.geolatte.geom.crs.CoordinateReferenceSystems.hasVerticalAxis;
+
+import org.geolatte.geom.ByteBuffer;
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.Position;
+import org.geolatte.geom.crs.CoordinateReferenceSystem;
+
+/**
+ * The HANA EWKB representation differs from the Postgis EWKB representation in
+ * that HANA always requires an SRID to be written, even if its not specified or 0.
+ * 
+ * @author Jonathan Bregler, SAP
+ */
+class HANAWkbEncoder extends PostgisWkbEncoder {
+
+	@Override
+	protected <P extends Position> int calculateSize(Geometry<P> geom, boolean includeSrid) {
+		int size = super.calculateSize(geom, includeSrid);
+		// HANA always expects the SRID, the Postgis encoder doesn't write it unless it's > 0 
+		return (includeSrid && geom.getSRID() <= 0) ? size + 4 : size;
+	}
+
+	@Override
+	protected <P extends Position> WkbVisitor<P> newWkbVisitor(ByteBuffer output, Geometry<P> geom) {
+		return new HANAWkbVisitor<P>(output);
+	}
+
+	static private class HANAWkbVisitor<P extends Position> extends WkbVisitor<P> {
+
+		private boolean hasWrittenSrid = false;
+
+		HANAWkbVisitor(ByteBuffer byteBuffer) {
+			super(byteBuffer);
+		}
+
+		@Override
+		protected void writeTypeCodeAndSrid(Geometry<P> geometry, ByteBuffer output) {
+			int typeCode = getGeometryType(geometry);
+			CoordinateReferenceSystem<P> crs = geometry.getCoordinateReferenceSystem();
+			if (!this.hasWrittenSrid) {
+				typeCode |= PostgisWkbTypeMasks.SRID_FLAG;
+			}
+			if (hasMeasureAxis(crs)) {
+				typeCode |= PostgisWkbTypeMasks.M_FLAG;
+			}
+			if (hasVerticalAxis(crs)) {
+				typeCode |= PostgisWkbTypeMasks.Z_FLAG;
+			}
+			output.putUInt(typeCode);
+			if (!this.hasWrittenSrid) {
+				int srid = geometry.getSRID();
+				// Write the SRID, the HANA default SRID is 0
+				output.putInt(srid < 0 ? 0 : srid);
+				this.hasWrittenSrid = true;
+			}
+		}
+
+	}
+
+}

--- a/src/main/java/org/geolatte/geom/codec/HANAWktDecoder.java
+++ b/src/main/java/org/geolatte/geom/codec/HANAWktDecoder.java
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the GeoLatte project.
+ *
+ *     GeoLatte is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     GeoLatte is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010 - 2017 and Ownership of code is shared by:
+ * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
+ * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
+ */
+package org.geolatte.geom.codec;
+
+/**
+ * The HANA EWKT decoder is equivalent to the Postgis EWKT decoder and is there
+ * mostly for symmetry reasons.
+ * 
+ * @author Jonathan Bregler, SAP
+ */
+class HANAWktDecoder extends PostgisWktDecoder {
+
+}

--- a/src/main/java/org/geolatte/geom/codec/HANAWktEncoder.java
+++ b/src/main/java/org/geolatte/geom/codec/HANAWktEncoder.java
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the GeoLatte project.
+ *
+ *     GeoLatte is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     GeoLatte is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010 - 2017 and Ownership of code is shared by:
+ * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
+ * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
+ */
+package org.geolatte.geom.codec;
+
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.Position;
+
+/**
+ * The HANA EWKT representation differs from the Postgis EWKT representation in
+ * that HANA always requires an SRID to be written, even if its not specified or 0.
+ * 
+ * @author Jonathan Bregler, SAP
+ */
+class HANAWktEncoder extends PostgisWktEncoder {
+
+	@Override
+	public <P extends Position> String encode(Geometry<P> geometry) {
+		String wkt = super.encode( geometry );
+		if ( wkt == null ) {
+			return null;
+		}
+
+		if ( !wkt.startsWith( "SRID=" ) ) {
+			StringBuilder sb = new StringBuilder( wkt.length() + 16 );
+			sb.append( "SRID=" );
+			// Write the SRID, the HANA default SRID is 0
+			if ( geometry.getSRID() < 0 ) {
+				sb.append( 0 );
+			}
+			else {
+				sb.append( geometry.getSRID() );
+			}
+			sb.append( ";" );
+			sb.append( wkt );
+			wkt = sb.toString();
+		}
+		return wkt;
+	}
+}

--- a/src/main/java/org/geolatte/geom/codec/Wkb.java
+++ b/src/main/java/org/geolatte/geom/codec/Wkb.java
@@ -42,7 +42,8 @@ public class Wkb {
     public enum Dialect {
         //the PostGIS EWKB dialect (versions 1.0 to 1.6).
         POSTGIS_EWKB_1,
-        MYSQL_WKB
+        MYSQL_WKB,
+        HANA_EWKB
     }
 
     private static final Dialect DEFAULT_DIALECT = Dialect.POSTGIS_EWKB_1;
@@ -53,8 +54,10 @@ public class Wkb {
     static {
         DECODERS.put(Dialect.POSTGIS_EWKB_1, PostgisWkbDecoder.class);
         DECODERS.put(Dialect.MYSQL_WKB, MySqlWkbDecoder.class);
+        DECODERS.put(Dialect.HANA_EWKB, HANAWkbDecoder.class);
         ENCODERS.put(Dialect.POSTGIS_EWKB_1, PostgisWkbEncoder.class);
         ENCODERS.put(Dialect.MYSQL_WKB, MySqlWkbEncoder.class);
+        ENCODERS.put(Dialect.HANA_EWKB, HANAWkbEncoder.class);
     }
 
 

--- a/src/main/java/org/geolatte/geom/codec/Wkt.java
+++ b/src/main/java/org/geolatte/geom/codec/Wkt.java
@@ -41,7 +41,8 @@ public class Wkt {
     public enum Dialect {
         //the PostGIS EWKT dialect (versions 1.0 to 1.5).
         POSTGIS_EWKT_1,
-        MYSQL_WKT
+        MYSQL_WKT,
+        HANA_EWKT
     }
 
     private static final Dialect DEFAULT_DIALECT = Dialect.POSTGIS_EWKT_1;
@@ -52,8 +53,10 @@ public class Wkt {
     static {
         DECODERS.put(Dialect.POSTGIS_EWKT_1, PostgisWktDecoder.class);
         DECODERS.put(Dialect.MYSQL_WKT, PostgisWktDecoder.class); // use also the PostgisWktDecoder since it can handle everything from Mysql
+        DECODERS.put(Dialect.HANA_EWKT, HANAWktDecoder.class);
         ENCODERS.put(Dialect.POSTGIS_EWKT_1, PostgisWktEncoder.class);
         ENCODERS.put(Dialect.MYSQL_WKT, PostgisWktEncoder.class); // this is temporary, not everything it produces can be understood by MySQL
+        ENCODERS.put(Dialect.HANA_EWKT, HANAWktEncoder.class);
     }
 
 

--- a/src/test/java/org/geolatte/geom/codec/HANACodecUnitTests.java
+++ b/src/test/java/org/geolatte/geom/codec/HANACodecUnitTests.java
@@ -1,0 +1,138 @@
+/*
+ * This file is part of the GeoLatte project.
+ *
+ *     GeoLatte is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     GeoLatte is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with GeoLatte.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2010 - 2012 and Ownership of code is shared by:
+ * Qmino bvba - Romeinsestraat 18 - 3001 Heverlee  (http://www.qmino.com)
+ * Geovise bvba - Generaal Eisenhowerlei 9 - 2140 Antwerpen (http://www.geovise.com)
+ */
+
+package org.geolatte.geom.codec;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.geolatte.geom.ByteBuffer;
+import org.geolatte.geom.ByteOrder;
+import org.geolatte.geom.Geometry;
+import org.geolatte.geom.support.PostgisJDBCUnitTestInputs;
+import org.geolatte.geom.support.PostgisJDBCWithSRIDTestInputs;
+import org.geolatte.geom.support.WktWkbCodecTestBase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import junit.framework.Assert;
+
+/**
+ * @author Jonathan Bregler
+ */
+public class HANACodecUnitTests extends CodecUnitTestBase {
+
+	static final private Logger LOGGER = LoggerFactory.getLogger(HANACodecUnitTests.class);
+
+	PostgisJDBCWithSRIDTestInputs testCases = new PostgisJDBCWithSRIDTestInputs();
+	WktDecoder wktDecoder = Wkt.newDecoder(Wkt.Dialect.HANA_EWKT);
+	WktEncoder wktEncoder = Wkt.newEncoder(Wkt.Dialect.HANA_EWKT);
+	WkbDecoder wkbDecoder = Wkb.newDecoder(Wkb.Dialect.HANA_EWKB);
+	WkbEncoder wkbEncoder = Wkb.newEncoder(Wkb.Dialect.HANA_EWKB);
+	
+    @Test
+    public void test_wkt_codec_without_srid() {
+    	PostgisJDBCUnitTestInputs testCases = new PostgisJDBCUnitTestInputs();
+        for (Integer testCase : testCases.getCases()) {
+            String wkt = addSRID(testCases.getWKT(testCase));
+            Geometry geom = getWktDecoder().decode(wkt);
+            assertEquals(String.format("Wkt decoder gives incorrect result for case: %d : ", testCase) + wkt, testCases.getExpected(testCase), geom);
+            if (testCases.getTestEncoding(testCase)) {
+                Assert.assertEquals("Wkt encoder gives incorrect result for case:" + wkt, wkt, getWktEncoder().encode(geom));
+            }
+        }
+    }
+
+    @Test
+    public void test_wkb_codec_without_srid() {
+    	PostgisJDBCUnitTestInputs testCases = new PostgisJDBCUnitTestInputs();
+        for (Integer testCase : testCases.getCases()) {
+            ByteBuffer wkb = addSRID(testCases.getWKB(testCase));
+            Geometry geom = getWkbDecoder().decode(wkb);
+            Assert.assertEquals("WKB decoder gives incorrect result for case: " + testCase, testCases.getExpected(testCase), geom);
+            Assert.assertEquals("WKB encoder gives incorrect result for case: " + testCase, wkb, getWkbEncoder().encode(geom, ByteOrder.NDR));
+            Assert.assertEquals("WKB encoder gives incorrect result for case: " + testCase, wkb, getWkbEncoder().encode(testCases.getExpected(testCase), ByteOrder.NDR));
+        }
+    }
+    
+    private ByteBuffer addSRID(ByteBuffer wkb) {
+    	byte[] bytes = wkb.toByteArray();
+    	byte[] eBytes = new byte[bytes.length + 4];
+    	
+    	eBytes[0] = bytes[0]; // byte order
+    	if (eBytes[0] == 1) {
+    		// little endian
+    		eBytes[1] = bytes[1];
+    		eBytes[2] = bytes[2];
+    		eBytes[3] = bytes[3];
+    		eBytes[4] = (byte)(bytes[4] | 0x20);
+    	}
+    	else {
+    		// big endian
+    		eBytes[1] = (byte)(bytes[1] | 0x20);
+    		eBytes[2] = bytes[2];
+    		eBytes[3] = bytes[3];
+    		eBytes[4] = bytes[4];
+    	}
+    	
+    	// add SRID 0
+		eBytes[5] = 0;
+		eBytes[6] = 0;
+		eBytes[7] = 0;
+		eBytes[8] = 0;
+    	
+		// add remaining data
+    	for (int i = 5 ; i < bytes.length ; i++) {
+    		eBytes[i+4] = bytes[i];
+    	}
+
+    	return ByteBuffer.from( eBytes );
+    }
+    
+    private String addSRID(String wkt) {
+    	return "SRID=0;" + wkt;
+    }
+
+	@Override
+	protected WktWkbCodecTestBase getTestCases() {
+		return this.testCases;
+	}
+
+	@Override
+	protected WktDecoder getWktDecoder() {
+		return this.wktDecoder;
+	}
+
+	@Override
+	protected WktEncoder getWktEncoder() {
+		return this.wktEncoder;
+	}
+
+	@Override
+	protected WkbDecoder getWkbDecoder() {
+		return this.wkbDecoder;
+	}
+
+	@Override
+	protected WkbEncoder getWkbEncoder() {
+		return this.wkbEncoder;
+	}
+}


### PR DESCRIPTION
This change adds EWKT and EWKB encoders and decoders for the SAP HANA
database. The existing Postgis EWKB and EWKT encoders don't write the
SRID if it's 0 or not set. HANA, however, always requires the SRID to
be present in the EWKB or EWKT representation. Another difference is how M and Z
coordinates are represented in the EWKB format. Postgis uses special flags in
the type code whereas HANA uses the type code ranges 1000+, 2000+, and 3000+ to
indicate these additional coordinates. This change adds encoders and decoders
for SAP HANA as extensions of the Postgis encoders which address those
differences.