### PR TITLE
Upgrade JTS to version 1.14.0

### DIFF
--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -35,8 +35,8 @@
 		<!-- Runtime dependencies -->
 		<dependency>
 			<groupId>com.vividsolutions</groupId>
-			<artifactId>jts</artifactId>
-			<version>1.13</version>
+			<artifactId>jts-core</artifactId>
+			<version>1.14.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
jts 1.13 is rather old and when using with eg. geotools I end up with both 1.13 (required by geolatte-geom) and 1.14.0 (required by geotools)