### PR TITLE
Invalid arcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ atlassian-ide-plugin.xml
 *.iws
 target
 javadoc/*
+**/.classpath
+**/.project
+**/.settings
+**/bin

--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -71,10 +71,11 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Commons collection as specified in original pom is broken for us -->
 		<dependency>
-			<groupId>org.apache.directory.studio</groupId>
-			<artifactId>org.apache.commons.collections</artifactId>
-			<version>3.2.1</version>
+			<groupId>commons-collections</groupId>
+			<artifactId>commons-collections</artifactId>
+			<version>3.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/geom/src/main/java/org/geolatte/geom/PolygonEnvelope.java
+++ b/geom/src/main/java/org/geolatte/geom/PolygonEnvelope.java
@@ -1,0 +1,51 @@
+package org.geolatte.geom;
+
+import org.geolatte.geom.crs.CoordinateReferenceSystem;
+
+/**
+ * <p>
+ * This is just a subclass of {@link Polygon} used within ORACLE spatial only.
+ * </p>
+ * <p>
+ * In some special cases it is needed to find out if a polygon in ORACLE is
+ * defined as a rectangle.<br>
+ * GEOGRAT GISX 2.x is using this behaviour to store geometries that are not
+ * compatible to ORACLE SDO specification. In this case the entity in hibernate
+ * spatial needs to know if a polygon is such an envelope.<br>
+ * Using function in polygon to check it is an envelope is not enough in this
+ * case, because there maybe geometries consisting of real envelopes.
+ * </p>
+ * 
+ * @author Christian Marsch
+ */
+public class PolygonEnvelope<P extends Position> extends Polygon<P> {
+
+	/**
+	 * @param crs
+	 *            see {@link Polygon#Polygon(CoordinateReferenceSystem)}
+	 */
+	public PolygonEnvelope(CoordinateReferenceSystem<P> crs) {
+		super(crs);
+	}
+
+	/**
+	 * @param positionSequence
+	 *            see
+	 *            {@link Polygon#Polygon(PositionSequence, CoordinateReferenceSystem)}
+	 * @param crs
+	 *            see
+	 *            {@link Polygon#Polygon(PositionSequence, CoordinateReferenceSystem)}
+	 */
+	public PolygonEnvelope(PositionSequence<P> positionSequence, CoordinateReferenceSystem<P> crs) {
+		super(positionSequence, crs);
+	}
+
+	/**
+	 * @param rings
+	 *            see {@link Polygon#Polygon(LinearRing...)}
+	 */
+	public PolygonEnvelope(LinearRing<P>... rings) {
+		super(rings);
+	}
+
+}

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/AbstractSDODecoder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/AbstractSDODecoder.java
@@ -86,7 +86,11 @@ abstract public class AbstractSDODecoder implements Decoder<SDOGeometry> {
             buffer[componentIdx] = oordinates[posIdx * dim + componentIdx]; //y
             if (zDim > 0) {
                 componentIdx++;
-                buffer[componentIdx] = oordinates[posIdx * dim + zDim];
+                /*
+                 * Z ordinate can be null! This is valid in ORACLE, but leads to an NPE because of autoboxing.
+                 */
+                Double zOrdinate = oordinates[posIdx * dim + zDim];
+                buffer[componentIdx] = zOrdinate == null ? Double.NaN : zOrdinate;
             }
             if (lrsDim > 0) {
                 componentIdx++;

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/PolygonSdoDecoder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/PolygonSdoDecoder.java
@@ -3,6 +3,7 @@ package org.geolatte.geom.codec.db.oracle;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.LinearRing;
 import org.geolatte.geom.Polygon;
+import org.geolatte.geom.PolygonEnvelope;
 import org.geolatte.geom.PositionSequence;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 
@@ -42,7 +43,15 @@ public class PolygonSdoDecoder extends AbstractSDODecoder {
             }
             i += 1 + numCompounds;
         }
-        return new Polygon(rings);
+		/*
+		 * In a very special case implementor needs to know that a polygon just
+		 * represents a rectangle.
+		 */
+		if (info.getSize() == 1 && info.getElementType(0).isRect()) {
+			return new PolygonEnvelope(rings);
+		} else {
+			return new Polygon(rings);
+		}
 
     }
 }

--- a/geom/src/main/java/org/geolatte/geom/jts/JTS.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/JTS.java
@@ -45,6 +45,12 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class JTS {
 
+	/**
+	 * Set as value in {@link Geometry#setUserData(Object)} if geometry to convert to JTS is of type
+	 * {@link PolygonEnvelope}.
+	 */
+	public static final String JTS_USER_OBJECT_ORACLE_RECTANGLE = "oracleRectangle";
+	
     private static final PointSequenceCoordinateSequenceFactory pscsFactory = new
             PointSequenceCoordinateSequenceFactory();
 
@@ -375,7 +381,15 @@ public class JTS {
         for (int i = 0; i < holes.length; i++) {
             holes[i] = to(polygon.getInteriorRingN(i), gFact);
         }
-        return gFact.createPolygon(shell, holes);
+        final Polygon jtsPolygon = gFact.createPolygon(shell, holes);
+        
+        /*
+         * Save to user data if it was original stored as rectangle.
+         */
+        if (polygon instanceof PolygonEnvelope) {
+			jtsPolygon.setUserData(JTS_USER_OBJECT_ORACLE_RECTANGLE);
+		}
+        return jtsPolygon;
     }
 
     private static <P extends Position> Point to(org.geolatte.geom.Point<P> point, GeometryFactory gFact) {

--- a/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
@@ -492,4 +492,29 @@ public class GeogratTests {
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Point);
 	}
+	
+	@Test
+	public void testOracleRectangle() {
+		SDOGeometry sdo = SDOGeometryHelper.sdoGeometry(3003, 0, null, new int[] { 1, 1003, 3 },
+				new Double[] { 3559406.367, 5331451.466, 0.0, 3559407.369, 5331454.681, 0.0 });
+		@SuppressWarnings("unchecked")
+		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		Assert.assertTrue(jtsGeo.isValid());
+		Assert.assertTrue(jtsGeo instanceof Polygon);
+		Assert.assertTrue(jtsGeo.isRectangle());
+		Assert.assertEquals(JTS.JTS_USER_OBJECT_ORACLE_RECTANGLE, jtsGeo.getUserData());
+	}
+
+	@Test
+	public void testOraclePolygonContainingNotOnlyRectangle() {
+		SDOGeometry sdo = SDOGeometryHelper.sdoGeometry(2003, 0, null, new int[] { 1, 1003, 1, 19, 2003, 3 },
+				new Double[] { 2.0, 4.0, 4.0, 3.0, 10.0, 3.0, 13.0, 5.0, 13.0, 9.0, 11.0, 13.0, 5.0, 13.0, 2.0, 11.0,
+						2.0, 4.0, 7.0, 5.0, 10.0, 10.0 });
+		@SuppressWarnings("unchecked")
+		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		Assert.assertTrue(jtsGeo.isValid());
+		Assert.assertTrue(jtsGeo instanceof Polygon);
+		Assert.assertFalse(jtsGeo.isRectangle());
+		Assert.assertNull(jtsGeo.getUserData());
+	}
 }

--- a/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
@@ -11,6 +11,7 @@ import org.geolatte.geom.jts.JTS;
 import org.junit.Assert;
 import org.junit.Test;
 import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;
 
 /**
@@ -480,4 +481,15 @@ public class GeogratTests {
 		Assert.assertTrue(!jtsGeo.isRectangle());
 	}
 
+	@Test
+	public void testPointWithNullZ() {
+
+		SDOGeometry sdo =
+				SDOGeometryHelper.sdoGeometry(3001, 0, new SDOPoint(33376662.068, 6019344.242, null), null, null);
+
+		@SuppressWarnings("unchecked")
+		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		Assert.assertTrue(jtsGeo.isValid());
+		Assert.assertTrue(jtsGeo instanceof Point);
+	}
 }


### PR DESCRIPTION
This Pull Request contains three changes I have made for GEOGRAT.
1. Some of our customers had a NPE because they got an SDO_POINT in ORACLE with Z part being "null". This was because of Autoboxing and conversion of null Double to double.
2. Improvement needed by GEOGRAT to return if a polygon / geometry was stored as ORACLE BoundingBox
3. This may be the most interesseting for community:
I found a bug concerning linearization of linestrings. In some cases linearization used to wrong direction and linearized counter-clockwise, but clockwise was required.
I demonstrated this by org.geolatte.geom.cga.CircularArcLinearizerTest.testArcClockwise():
Without the fix this test will fail, because linearization of arc is done counter-clockwise.

Feel free the include into master if you like too.

Sorry that this may contain my changes in pom.xml too. Did those changes becuase I had some problems concerning collections api and because of own versioning.
