### PR TITLE
[WIP] upgrade JTS to current release

### DIFF
--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
-			<version>1.15.1</version>
+			<version>1.16.0-RC1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -34,9 +34,9 @@
 	<dependencies>
 		<!-- Runtime dependencies -->
 		<dependency>
-			<groupId>com.vividsolutions</groupId>
+			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
-			<version>1.14.0</version>
+			<version>1.15.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/geom/src/main/java/org/geolatte/geom/AbstractPositionSequence.java
+++ b/geom/src/main/java/org/geolatte/geom/AbstractPositionSequence.java
@@ -21,8 +21,8 @@
 
 package org.geolatte.geom;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.Envelope;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Envelope;
 import org.geolatte.geom.jts.DimensionalCoordinate;
 
 import java.io.Serializable;
@@ -38,8 +38,8 @@ abstract class AbstractPositionSequence<P extends Position> implements PositionS
         this.factory = factory;
     }
 
-    private static com.vividsolutions.jts.geom.Coordinate[] toCoordinateArray(AbstractPositionSequence cseq) {
-        com.vividsolutions.jts.geom.Coordinate[] coordinates = new com.vividsolutions.jts.geom.Coordinate[cseq.size()];
+    private static org.locationtech.jts.geom.Coordinate[] toCoordinateArray(AbstractPositionSequence cseq) {
+        org.locationtech.jts.geom.Coordinate[] coordinates = new org.locationtech.jts.geom.Coordinate[cseq.size()];
         for (int i = 0; i < cseq.size(); i++) {
             coordinates[i] = cseq.getCoordinate(i);
 
@@ -106,7 +106,7 @@ abstract class AbstractPositionSequence<P extends Position> implements PositionS
 //    }
 
 
-    public com.vividsolutions.jts.geom.Coordinate getCoordinate(int i) {
+    public org.locationtech.jts.geom.Coordinate getCoordinate(int i) {
         DimensionalCoordinate co = new DimensionalCoordinate();
         double[] c = new double[getCoordinateDimension()];
         getCoordinates(i, c);
@@ -120,12 +120,12 @@ abstract class AbstractPositionSequence<P extends Position> implements PositionS
         return co;
     }
 
-    public com.vividsolutions.jts.geom.Coordinate getCoordinateCopy(int i) {
+    public org.locationtech.jts.geom.Coordinate getCoordinateCopy(int i) {
         return getCoordinate(i);
     }
 
     @Override
-    public void getCoordinate(int index, com.vividsolutions.jts.geom.Coordinate coord) {
+    public void getCoordinate(int index, org.locationtech.jts.geom.Coordinate coord) {
         double[] c = new double[getCoordinateDimension()];
         getCoordinates(index, c);
         coord.x = c[0];
@@ -171,7 +171,7 @@ abstract class AbstractPositionSequence<P extends Position> implements PositionS
     public abstract void setOrdinate(int i, int ordinateIndex, double value);
 
     @Override
-    public com.vividsolutions.jts.geom.Coordinate[] toCoordinateArray() {
+    public org.locationtech.jts.geom.Coordinate[] toCoordinateArray() {
         return toCoordinateArray(this);
     }
 

--- a/geom/src/main/java/org/geolatte/geom/Circle.java
+++ b/geom/src/main/java/org/geolatte/geom/Circle.java
@@ -24,8 +24,8 @@ package org.geolatte.geom;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.PrecisionModel;
 
 //TODO -- verify code, and place in utility class
 

--- a/geom/src/main/java/org/geolatte/geom/JTSGeometryOperations.java
+++ b/geom/src/main/java/org/geolatte/geom/JTSGeometryOperations.java
@@ -21,14 +21,14 @@
 
 package org.geolatte.geom;
 
-import com.vividsolutions.jts.algorithm.ConvexHull;
-import com.vividsolutions.jts.operation.BoundaryOp;
-import com.vividsolutions.jts.operation.IsSimpleOp;
-import com.vividsolutions.jts.operation.buffer.BufferOp;
-import com.vividsolutions.jts.operation.distance.DistanceOp;
-import com.vividsolutions.jts.operation.overlay.OverlayOp;
-import com.vividsolutions.jts.operation.overlay.snap.SnapIfNeededOverlayOp;
-import com.vividsolutions.jts.operation.relate.RelateOp;
+import org.locationtech.jts.algorithm.ConvexHull;
+import org.locationtech.jts.operation.BoundaryOp;
+import org.locationtech.jts.operation.IsSimpleOp;
+import org.locationtech.jts.operation.buffer.BufferOp;
+import org.locationtech.jts.operation.distance.DistanceOp;
+import org.locationtech.jts.operation.overlay.OverlayOp;
+import org.locationtech.jts.operation.overlay.snap.SnapIfNeededOverlayOp;
+import org.locationtech.jts.operation.relate.RelateOp;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.geolatte.geom.jts.JTS;
 
@@ -194,7 +194,7 @@ public class JTSGeometryOperations implements ProjectedGeometryOperations {
         if (geometry.isEmpty() || other.isEmpty()) return new Point<P>(geometry.getCoordinateReferenceSystem());
         checkNotGeometryCollection(geometry);
         checkNotGeometryCollection(other);
-        com.vividsolutions.jts.geom.Geometry intersection = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.INTERSECTION);
+        org.locationtech.jts.geom.Geometry intersection = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.INTERSECTION);
         return JTS.from(intersection, geometry.getCoordinateReferenceSystem());
     }
 
@@ -205,7 +205,7 @@ public class JTSGeometryOperations implements ProjectedGeometryOperations {
         if (other.isEmpty()) return geometry;
         checkNotGeometryCollection(geometry);
         checkNotGeometryCollection(other);
-        com.vividsolutions.jts.geom.Geometry union = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.UNION);
+        org.locationtech.jts.geom.Geometry union = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.UNION);
         return JTS.from(union, geometry.getCoordinateReferenceSystem());
 
     }
@@ -217,7 +217,7 @@ public class JTSGeometryOperations implements ProjectedGeometryOperations {
         if (other.isEmpty()) return geometry;
         checkNotGeometryCollection(geometry);
         checkNotGeometryCollection(other);
-        com.vividsolutions.jts.geom.Geometry difference = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.DIFFERENCE);
+        org.locationtech.jts.geom.Geometry difference = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.DIFFERENCE);
         return JTS.from(difference, geometry.getCoordinateReferenceSystem());
 
     }
@@ -229,7 +229,7 @@ public class JTSGeometryOperations implements ProjectedGeometryOperations {
                 if (other.isEmpty()) return geometry;
                 checkNotGeometryCollection(geometry);
                 checkNotGeometryCollection(other);
-                com.vividsolutions.jts.geom.Geometry symDifference = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.SYMDIFFERENCE);
+                org.locationtech.jts.geom.Geometry symDifference = SnapIfNeededOverlayOp.overlayOp(JTS.to(geometry), JTS.to(other), OverlayOp.SYMDIFFERENCE);
                 return JTS.from(symDifference, geometry.getCoordinateReferenceSystem());
     }
 

--- a/geom/src/main/java/org/geolatte/geom/NestedPositionSequence.java
+++ b/geom/src/main/java/org/geolatte/geom/NestedPositionSequence.java
@@ -21,7 +21,7 @@
 
 package org.geolatte.geom;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequence;
 
 import java.util.Arrays;
 import java.util.Iterator;

--- a/geom/src/main/java/org/geolatte/geom/NestedPositionSequence.java
+++ b/geom/src/main/java/org/geolatte/geom/NestedPositionSequence.java
@@ -86,8 +86,15 @@ class NestedPositionSequence<P extends Position> extends AbstractPositionSequenc
         return this.size;
     }
 
+    /** @deprecated in {@link org.locationtech.jts.geom.CoordinateSequence }.*/
+    @Deprecated
     @Override
     public NestedPositionSequence<P> clone() {
+        return this; //this is correct since this object is immutable.
+    }
+
+    @Override
+    public NestedPositionSequence<P> copy() {
         return this; //this is correct since this object is immutable.
     }
 

--- a/geom/src/main/java/org/geolatte/geom/PackedPositionSequence.java
+++ b/geom/src/main/java/org/geolatte/geom/PackedPositionSequence.java
@@ -91,8 +91,15 @@ class PackedPositionSequence<P extends Position> extends AbstractPositionSequenc
         return new PositionSequenceIterator<P>(this);
     }
 
+    /** @deprecated in {@link org.locationtech.jts.geom.CoordinateSequence }.*/
+    @Deprecated
     @Override
     public PositionSequence<P> clone() {
+        return new PackedPositionSequence<>(getPositionFactory(), Arrays.copyOf(this.coordinates, this.coordinates.length));
+    }
+
+    @Override
+    public PackedPositionSequence<P> copy() {
         return new PackedPositionSequence<>(getPositionFactory(), Arrays.copyOf(this.coordinates, this.coordinates.length));
     }
 

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/SdoPolygonEncoder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/SdoPolygonEncoder.java
@@ -1,6 +1,6 @@
 package org.geolatte.geom.codec.db.oracle;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.GeometryType;
 import org.geolatte.geom.Polygon;

--- a/geom/src/main/java/org/geolatte/geom/jts/DimensionalCoordinate.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/DimensionalCoordinate.java
@@ -43,13 +43,12 @@ public class DimensionalCoordinate extends Coordinate {
         this.m = m;
     }
 
-    public double getZ(){
-        return  this.z;
-    }
-
+    @Override
     public double getM(){
         return this.m;
     }
 
+    @Override
+    public void setM(double m) { this.m = m; }
 
 }

--- a/geom/src/main/java/org/geolatte/geom/jts/DimensionalCoordinate.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/DimensionalCoordinate.java
@@ -21,7 +21,7 @@
 
 package org.geolatte.geom.jts;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Coordinate;
 
 /**
  * A <code>Coordinate</code> with an associated <code>DimensionalFlag</code>.

--- a/geom/src/main/java/org/geolatte/geom/jts/JTS.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/JTS.java
@@ -21,16 +21,16 @@
 
 package org.geolatte.geom.jts;
 
-import com.vividsolutions.jts.geom.*;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiLineString;
-import com.vividsolutions.jts.geom.MultiPoint;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.*;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiLineString;
+import org.locationtech.jts.geom.MultiPoint;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 import org.geolatte.geom.*;
 import org.geolatte.geom.crs.*;
 
@@ -117,7 +117,7 @@ public class JTS {
      * @return an equivalent geolatte geometry
      * @throws IllegalArgumentException when a null object is passed
      */
-    public static org.geolatte.geom.Geometry<?> from(com.vividsolutions.jts.geom.Geometry jtsGeometry) {
+    public static org.geolatte.geom.Geometry<?> from(org.locationtech.jts.geom.Geometry jtsGeometry) {
         if (jtsGeometry == null) {
             throw new IllegalArgumentException("Null object passed.");
         }
@@ -179,7 +179,7 @@ public class JTS {
      * @return the equivalent JTS geometry
      * @throws IllegalArgumentException when a null object is passed
      */
-    public static <P extends Position> com.vividsolutions.jts.geom.Geometry to(org.geolatte.geom.Geometry<P> geometry, GeometryFactory gFact) {
+    public static <P extends Position> org.locationtech.jts.geom.Geometry to(org.geolatte.geom.Geometry<P> geometry, GeometryFactory gFact) {
         if (geometry == null || gFact == null) {
             throw new IllegalArgumentException("Null object passed.");
         }
@@ -202,7 +202,7 @@ public class JTS {
         }
     }
 
-    public static <P extends Position> com.vividsolutions.jts.geom.Geometry to(org.geolatte.geom.Geometry<P> geometry) {
+    public static <P extends Position> org.locationtech.jts.geom.Geometry to(org.geolatte.geom.Geometry<P> geometry) {
         if (geometry == null) {
             throw new IllegalArgumentException("Null object passed.");
         }
@@ -226,7 +226,7 @@ public class JTS {
      * @return the corresponding geolatte Envelope.
      * @throws IllegalArgumentException when a null object is passed
      */
-    public static org.geolatte.geom.Envelope<C2D> from(com.vividsolutions.jts.geom.Envelope jtsEnvelope) {
+    public static org.geolatte.geom.Envelope<C2D> from(org.locationtech.jts.geom.Envelope jtsEnvelope) {
         if (jtsEnvelope == null) {
             throw new IllegalArgumentException("Null object passed.");
         }
@@ -243,7 +243,7 @@ public class JTS {
      * @return the corresponding geolatte Envelope, having the CRS specified in the crsId parameter.
      * @throws IllegalArgumentException when a null object is passed
      */
-    public static <P extends Position> org.geolatte.geom.Envelope<P> from(com.vividsolutions.jts.geom.Envelope
+    public static <P extends Position> org.geolatte.geom.Envelope<P> from(org.locationtech.jts.geom.Envelope
                                                                                   jtsEnvelope,
                                                                           CoordinateReferenceSystem<P> crs) {
         if (jtsEnvelope == null) {
@@ -260,11 +260,11 @@ public class JTS {
      * @return the corresponding JTS Envelope.
      * @throws IllegalArgumentException when a null object is passed
      */
-    public static com.vividsolutions.jts.geom.Envelope to(org.geolatte.geom.Envelope<?> env) {
+    public static org.locationtech.jts.geom.Envelope to(org.geolatte.geom.Envelope<?> env) {
         if (env == null) {
             throw new IllegalArgumentException("Null object passed.");
         }
-        return new com.vividsolutions.jts.geom.Envelope(env.lowerLeft().getCoordinate(0), env.upperRight()
+        return new org.locationtech.jts.geom.Envelope(env.lowerLeft().getCoordinate(0), env.upperRight()
                 .getCoordinate(0), env.lowerLeft().getCoordinate(1), env.upperRight().getCoordinate(1));
     }
 
@@ -367,7 +367,7 @@ public class JTS {
     /*
      * Converts a jts point into a geolatte point
      */
-    private static <P extends Position> org.geolatte.geom.Point<P> from(com.vividsolutions.jts.geom.Point jtsPoint,
+    private static <P extends Position> org.geolatte.geom.Point<P> from(org.locationtech.jts.geom.Point jtsPoint,
                                                                         CoordinateReferenceSystem<P> crs) {
         CoordinateSequence cs = jtsPoint.getCoordinateSequence();
         return new org.geolatte.geom.Point<P>(pscsFactory.toPositionSequence(cs, crs.getPositionClass(), crs), crs);

--- a/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
@@ -100,7 +100,7 @@ class PointSequenceCoordinateSequenceFactory implements CoordinateSequenceFactor
         if (coordinates[0] instanceof DimensionalCoordinate) {
             hasM = !Double.isNaN(((DimensionalCoordinate) coordinates[0]).getM());
         }
-        hasZ = !Double.isNaN(coordinates[0].z);
+        hasZ = !Double.isNaN(coordinates[0].getZ());
         if (hasM && hasZ) {
             return PROJECTED_3DM_METER;
         } else if (hasM) {
@@ -126,15 +126,15 @@ class PointSequenceCoordinateSequenceFactory implements CoordinateSequenceFactor
     }
 
     private <P extends Position> void copy(Coordinate co, double[] ordinates, CoordinateReferenceSystem<P> crs) {
-        ordinates[0] = co.x;
-        ordinates[1] = co.y;
+        ordinates[0] = co.getX();
+        ordinates[1] = co.getY();
         boolean hasVerticalAxis = hasVerticalAxis(crs);
         if (hasVerticalAxis) {
-            ordinates[2] = co.z;
+            ordinates[2] = co.getZ();
         }
         if (hasMeasureAxis(crs)) {
             int idxM = hasVerticalAxis ? 3 : 2;
-            ordinates[idxM] = (co instanceof DimensionalCoordinate) ? ((DimensionalCoordinate) co).m : Double.NaN;
+            ordinates[idxM] = (co instanceof DimensionalCoordinate) ? ((DimensionalCoordinate) co).getM() : Double.NaN;
         }
     }
 

--- a/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
@@ -21,10 +21,10 @@
 
 package org.geolatte.geom.jts;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequence;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.impl.CoordinateArraySequence;
 import org.geolatte.geom.*;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 

--- a/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
@@ -58,8 +58,8 @@ class PointSequenceCoordinateSequenceFactory implements CoordinateSequenceFactor
         // This is causing problems when working with Geotools JTS class in
         // transformation.
         // This is just a quick fix in order to get this working...
-        if (dimension > 3)
-            throw new IllegalArgumentException("dimension must be <= 3");
+//        if (dimension > 3)
+//            throw new IllegalArgumentException("dimension must be <= 3");
         return new CoordinateArraySequence(size, dimension);
     }
 

--- a/geom/src/test/java/org/geolatte/geom/MultiPointTest.java
+++ b/geom/src/test/java/org/geolatte/geom/MultiPointTest.java
@@ -52,7 +52,7 @@ public class MultiPointTest {
 
     @Test
     public void testAsJTS() throws Exception {
-        com.vividsolutions.jts.geom.Geometry jtsMP = JTS.to(pnt1);
+        org.locationtech.jts.geom.Geometry jtsMP = JTS.to(pnt1);
         assertEquals(jtsMP.getNumGeometries(), pnt1.getNumGeometries());
         for (int i = 0; i < pnt1.getNumGeometries(); i++) {
             assertEquals(jtsMP.getGeometryN(i).getCoordinate().x, pnt1.getGeometryN(i).getPosition().getCoordinate(0), Math.ulp(100));

--- a/geom/src/test/java/org/geolatte/geom/PackedPointSequenceTest.java
+++ b/geom/src/test/java/org/geolatte/geom/PackedPointSequenceTest.java
@@ -21,8 +21,8 @@
 
 package org.geolatte.geom;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/geom/src/test/java/org/geolatte/geom/SerializableTest.java
+++ b/geom/src/test/java/org/geolatte/geom/SerializableTest.java
@@ -98,12 +98,12 @@ public class SerializableTest {
 
         ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
         Geometry<C2D> geom = point(crs, c(3, 4));
-        com.vividsolutions.jts.geom.Point jtsPoint = (com.vividsolutions.jts.geom.Point) JTS.to(geom);
+        org.locationtech.jts.geom.Point jtsPoint = (org.locationtech.jts.geom.Point) JTS.to(geom);
         ObjectOutputStream outputStream = new ObjectOutputStream(byteOutput);
         outputStream.writeObject(jtsPoint);
 
         ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(byteOutput.toByteArray()));
-        com.vividsolutions.jts.geom.Point geomOut = (com.vividsolutions.jts.geom.Point) inputStream.readObject();
+        org.locationtech.jts.geom.Point geomOut = (org.locationtech.jts.geom.Point) inputStream.readObject();
 
         assertEquals(jtsPoint, geomOut);
     }
@@ -113,12 +113,12 @@ public class SerializableTest {
     public void testSerializeJtsLineString() throws Exception {
 
         ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
-        com.vividsolutions.jts.geom.LineString jts = (com.vividsolutions.jts.geom.LineString) JTS.to(linestring(crs, c(3, 4), c(5, 5)));
+        org.locationtech.jts.geom.LineString jts = (org.locationtech.jts.geom.LineString) JTS.to(linestring(crs, c(3, 4), c(5, 5)));
         ObjectOutputStream outputStream = new ObjectOutputStream(byteOutput);
         outputStream.writeObject(jts);
 
         ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(byteOutput.toByteArray()));
-        com.vividsolutions.jts.geom.LineString geomOut = (com.vividsolutions.jts.geom.LineString) inputStream.readObject();
+        org.locationtech.jts.geom.LineString geomOut = (org.locationtech.jts.geom.LineString) inputStream.readObject();
 
         assertEquals(jts, geomOut);
     }
@@ -127,14 +127,14 @@ public class SerializableTest {
     public void testSerializeJtsMultiLineString() throws Exception {
 
         ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
-        com.vividsolutions.jts.geom.MultiLineString jts = (com.vividsolutions.jts.geom.MultiLineString) JTS.to(
+        org.locationtech.jts.geom.MultiLineString jts = (org.locationtech.jts.geom.MultiLineString) JTS.to(
                 multilinestring(crs, linestring(c(1, 1), c(4, 4)), linestring(c(3, 4), c(5, 5)))
         );
         ObjectOutputStream outputStream = new ObjectOutputStream(byteOutput);
         outputStream.writeObject(jts);
 
         ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(byteOutput.toByteArray()));
-        com.vividsolutions.jts.geom.MultiLineString geomOut = (com.vividsolutions.jts.geom.MultiLineString) inputStream.readObject();
+        org.locationtech.jts.geom.MultiLineString geomOut = (org.locationtech.jts.geom.MultiLineString) inputStream.readObject();
 
         assertEquals(jts, geomOut);
     }
@@ -144,14 +144,14 @@ public class SerializableTest {
     public void testSerializeJtsPolygon() throws Exception {
 
         ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
-        com.vividsolutions.jts.geom.Polygon jts = (com.vividsolutions.jts.geom.Polygon) JTS.to(
+        org.locationtech.jts.geom.Polygon jts = (org.locationtech.jts.geom.Polygon) JTS.to(
                 polygon(crs, ring(c(0, 0), c(1, 0), c(1, 1), c(0, 1), c(0, 0)))
         );
         ObjectOutputStream outputStream = new ObjectOutputStream(byteOutput);
         outputStream.writeObject(jts);
 
         ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(byteOutput.toByteArray()));
-        com.vividsolutions.jts.geom.Polygon geomOut = (com.vividsolutions.jts.geom.Polygon) inputStream.readObject();
+        org.locationtech.jts.geom.Polygon geomOut = (org.locationtech.jts.geom.Polygon) inputStream.readObject();
 
         assertEquals(jts, geomOut);
     }

--- a/geom/src/test/java/org/geolatte/geom/cga/CircularArcLinearizerTest.java
+++ b/geom/src/test/java/org/geolatte/geom/cga/CircularArcLinearizerTest.java
@@ -18,9 +18,9 @@ import org.geolatte.geom.support.generator.Generator;
 import org.geolatte.geom.support.generator.StdGenerators;
 import org.junit.Test;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 03/03/15.
@@ -232,7 +232,7 @@ public class CircularArcLinearizerTest {
     	LineString<C2D> lineString = new LineString<>(result,coordinateRefSystem);
     	Geometry jtsGeometry = JTS.to(lineString);
     	
-    	com.vividsolutions.jts.geom.LineString intersectGeometry = new GeometryFactory().createLineString(new Coordinate[] {new Coordinate(20.0, 20.0), new Coordinate(40.0, 20.0)});
+    	org.locationtech.jts.geom.LineString intersectGeometry = new GeometryFactory().createLineString(new Coordinate[] {new Coordinate(20.0, 20.0), new Coordinate(40.0, 20.0)});
     	assertTrue(jtsGeometry.intersects(intersectGeometry));
     }
     
@@ -246,7 +246,7 @@ public class CircularArcLinearizerTest {
     	LineString<C2D> lineString = new LineString<>(result,coordinateRefSystem);
     	Geometry jtsGeometry = JTS.to(lineString);
     	
-    	com.vividsolutions.jts.geom.LineString intersectGeometry = new GeometryFactory().createLineString(new Coordinate[] {new Coordinate(20.0, 20.0), new Coordinate(40.0, 20.0)});
+    	org.locationtech.jts.geom.LineString intersectGeometry = new GeometryFactory().createLineString(new Coordinate[] {new Coordinate(20.0, 20.0), new Coordinate(40.0, 20.0)});
     	assertTrue(jtsGeometry.intersects(intersectGeometry));
     }
 }

--- a/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/db/oracle/GeogratTests.java
@@ -10,9 +10,9 @@ package org.geolatte.geom.codec.db.oracle;
 import org.geolatte.geom.jts.JTS;
 import org.junit.Assert;
 import org.junit.Test;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.Polygon;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 /**
  * @author Christian Marsch
@@ -28,7 +28,7 @@ public class GeogratTests {
 						5943936.628, 0.0, 3569204.323, 5943986.624, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Polygon);
 		Assert.assertTrue(!jtsGeo.isRectangle());
@@ -41,7 +41,7 @@ public class GeogratTests {
 						5942919.687, 0.0, 3571875.563, 5944981.37752, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Polygon);
 		Assert.assertTrue(jtsGeo.isRectangle());
@@ -54,7 +54,7 @@ public class GeogratTests {
 						5942919.687, 0.0, 3571875.563, 5944981.37752, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Polygon);
 		Assert.assertTrue(jtsGeo.isRectangle());
@@ -70,7 +70,7 @@ public class GeogratTests {
 								5944170.3853, 0.0, 3568643.2332, 5944170.1415, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 
 		Assert.assertTrue(jtsGeo instanceof LineString);
@@ -88,7 +88,7 @@ public class GeogratTests {
 								3569548.9692, 5943673.2351, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 
 		Assert.assertTrue(jtsGeo instanceof Polygon);
@@ -285,7 +285,7 @@ public class GeogratTests {
 				});
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 
 		Assert.assertTrue(jtsGeo instanceof Polygon);
@@ -346,7 +346,7 @@ public class GeogratTests {
 						5944765.8, 0.0, 3571074.1333, 5944777.273, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Polygon);
 		Assert.assertTrue(!jtsGeo.isRectangle());
@@ -475,7 +475,7 @@ public class GeogratTests {
 						5944401.744, 0.0, 3568981.326, 5944402.154, 0.0, 3568981.365, 5944402.176, 0.0 });
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Polygon);
 		Assert.assertTrue(!jtsGeo.isRectangle());
@@ -488,7 +488,7 @@ public class GeogratTests {
 				SDOGeometryHelper.sdoGeometry(3001, 0, new SDOPoint(33376662.068, 6019344.242, null), null, null);
 
 		@SuppressWarnings("unchecked")
-		com.vividsolutions.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
+		org.locationtech.jts.geom.Geometry jtsGeo = JTS.to(Decoders.decode(sdo));
 		Assert.assertTrue(jtsGeo.isValid());
 		Assert.assertTrue(jtsGeo instanceof Point);
 	}

--- a/geom/src/test/java/org/geolatte/geom/jts/ReverseTest.java
+++ b/geom/src/test/java/org/geolatte/geom/jts/ReverseTest.java
@@ -1,6 +1,6 @@
 package org.geolatte.geom.jts;
 
-import com.vividsolutions.jts.geom.LineString;
+import org.locationtech.jts.geom.LineString;
 import org.junit.Test;
 
 import static org.geolatte.geom.CrsMock.*;

--- a/geom/src/test/java/org/geolatte/geom/jts/TestJTS.java
+++ b/geom/src/test/java/org/geolatte/geom/jts/TestJTS.java
@@ -21,8 +21,8 @@
 
 package org.geolatte.geom.jts;
 
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.GeometryCollection;
 import org.geolatte.geom.Measured;
@@ -80,7 +80,7 @@ public class TestJTS {
     public void test_measured_3d() {
         PostgisTestCases testCases = new PostgisTestCases();
         Geometry<?> geometry = testCases.getExpected(PostgisTestCases.LINESTRING_3DM);
-        com.vividsolutions.jts.geom.Geometry jtsGeometry = JTS.to(geometry);
+        org.locationtech.jts.geom.Geometry jtsGeometry = JTS.to(geometry);
         Assert.assertTrue(DimensionalCoordinate.class.isInstance(jtsGeometry.getCoordinates()[0]));
         DimensionalCoordinate dc = (DimensionalCoordinate) jtsGeometry.getCoordinates()[0];
         assertEquals(dc.getM(), 2, Math.ulp(2));
@@ -93,7 +93,7 @@ public class TestJTS {
     public void test_measured_2d() {
         PostgisTestCases testCases = new PostgisTestCases();
         Geometry<?> geometry = testCases.getExpected(PostgisTestCases.LINESTRING_2DM);
-        com.vividsolutions.jts.geom.Geometry jtsGeometry = JTS.to(geometry);
+        org.locationtech.jts.geom.Geometry jtsGeometry = JTS.to(geometry);
         Assert.assertTrue(DimensionalCoordinate.class.isInstance(jtsGeometry.getCoordinates()[0]));
         DimensionalCoordinate dc = (DimensionalCoordinate) jtsGeometry.getCoordinates()[0];
         assertEquals(dc.getM(), 2, Math.ulp(2));
@@ -151,13 +151,13 @@ public class TestJTS {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_null_arguments_from() {
-        JTS.from((com.vividsolutions.jts.geom.Geometry) null);
+        JTS.from((org.locationtech.jts.geom.Geometry) null);
 
     }
 
     @Test
     public void test_from_with_srid() {
-        com.vividsolutions.jts.geom.Geometry geometry = JTS.to(point(crs, c(1, 2)));
+        org.locationtech.jts.geom.Geometry geometry = JTS.to(point(crs, c(1, 2)));
         geometry.setSRID(4326);
         assertEquals(4326, JTS.from(geometry).getSRID());
 
@@ -173,7 +173,7 @@ public class TestJTS {
     }
 
     private void test_empty(Geometry empty) {
-        com.vividsolutions.jts.geom.Geometry jts = JTS.to(empty);
+        org.locationtech.jts.geom.Geometry jts = JTS.to(empty);
         assertTrue(jts.isEmpty());
         assertEquals(empty, JTS.from(jts, empty.getCoordinateReferenceSystem()));
     }
@@ -186,19 +186,19 @@ public class TestJTS {
             String failureMsg = "Failure in testcase " + testCase;
             String wkt = testCases.getWKT(testCase);
             Geometry geolatteGeom = wktDecoder.decode(wkt);
-            com.vividsolutions.jts.geom.Geometry jtsGeom = null;
+            org.locationtech.jts.geom.Geometry jtsGeom = null;
             jtsGeom = parseWKTtoJTS(wkt, jtsGeom);
             if (jtsGeom == null) {
                 //some EWKT forms cannot be parse, so in this case we just check that the To/From methods are consistent
-                com.vividsolutions.jts.geom.Geometry jts = JTS.to(geolatteGeom);
+                org.locationtech.jts.geom.Geometry jts = JTS.to(geolatteGeom);
                 assertEquals(String.format("Error for case %d", testCase), geolatteGeom, JTS.from(jts, geolatteGeom.getCoordinateReferenceSystem()));
                 continue;
             }
-            if (com.vividsolutions.jts.geom.GeometryCollection.class.isInstance(jtsGeom)) {
+            if (org.locationtech.jts.geom.GeometryCollection.class.isInstance(jtsGeom)) {
                 // JTS's equals method cannot handle GeometryCollection classes, so we just test
                 // if the types and number of items are equal
                 assertEquals(failureMsg, JTS.getCorrespondingGeolatteClass(jtsGeom.getClass()), geolatteGeom.getClass());
-                assertEquals(((com.vividsolutions.jts.geom.GeometryCollection) jtsGeom).getNumGeometries(),
+                assertEquals(((org.locationtech.jts.geom.GeometryCollection) jtsGeom).getNumGeometries(),
                         ((GeometryCollection) geolatteGeom).getNumGeometries());
                 continue;
             }
@@ -218,7 +218,7 @@ public class TestJTS {
         }
     }
 
-    private com.vividsolutions.jts.geom.Geometry parseWKTtoJTS(String wkt, com.vividsolutions.jts.geom.Geometry jtsGeom) {
+    private org.locationtech.jts.geom.Geometry parseWKTtoJTS(String wkt, org.locationtech.jts.geom.Geometry jtsGeom) {
         try {
             jtsGeom = jtsWktDecoder.read(wkt);
         } catch (ParseException e) {


### PR DESCRIPTION
The current release is 1.15.1, the latest release is 1.16.0-RC1, GeoTools 20.0 will be shipping with JTS 1.16.0 as a dependency.

currently running into some issues because JTS has started supporting Z and M dimensions so there are some failing tests.

Also JTS now has CoordinateXY, CoordinateXYM, CoordinateXYZM, see locationtech/jts#293