### PR TITLE
fix NPE for non-predefined WGS 84 GeographicCoordinateReferenceSystem

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/crs/CrsRegistry.java
+++ b/geom/src/main/java/org/geolatte/geom/crs/CrsRegistry.java
@@ -212,6 +212,7 @@ public class CrsRegistry {
 
     public static ProjectedCoordinateReferenceSystem getProjectedCoordinateReferenceSystemForEPSG(int epsgCode) {
         CoordinateReferenceSystem<? extends Position> crs = crsMap.get(CrsId.valueOf(epsgCode));
+        if (crs == null) return null;
         if (crs.getPositionClass().equals(C2D.class)) {
             return (ProjectedCoordinateReferenceSystem) crs;
         }


### PR DESCRIPTION
Solve the NullPointerException for scenarios when ProjectedCoordinateReferenceSystem is not defined for EPSG in **spatial_ref_sys.txt** file 