### PR TITLE
Fix isCounterClockwise implementation

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
+++ b/geom/src/main/java/org/geolatte/geom/cga/NumericalMethods.java
@@ -80,8 +80,7 @@ public class NumericalMethods {
     /**
      * Determines whether the specified {@code PositionSequence} is counter-clockwise.
      * <p/>
-     * <p>Only the first three positions, are inspected to determine whether the sequence is counter-clockwise.
-     * In case are less than three positions in the sequence, the method returns true.</p>
+     * <p>In case there are less than three positions in the sequence, the method returns true.</p>
      *
      * @param positions a {@code PositionSequence}
      * @return true if the positions in the specified sequence are counter-clockwise, or if the sequence contains
@@ -91,18 +90,18 @@ public class NumericalMethods {
         if (positions.size() < 3) return true;
         Position p0 = positions.getPositionN(0);
         Position p1 = positions.getPositionN(1);
-        double det = 0;
+        double summedDet = 0;
         int positionsSize = positions.size();
         int i = 2;
-        while(i < positionsSize && det == 0) {
+        while(i < positionsSize) {
             Position p2 = positions.getPositionN(i);
-            det = deltaDeterminant(p0, p1, p2);
+            summedDet += deltaDeterminant(p0, p1, p2);
             i++;
         }
-        if (det == 0) {
+        if (summedDet == 0) {
             throw new IllegalArgumentException("Positions are collinear in 2D");
         }
-        return det > 0;
+        return summedDet > 0;
     }
 
     /**

--- a/geom/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
+++ b/geom/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
@@ -2,6 +2,7 @@ package org.geolatte.geom.cga;
 
 import static org.geolatte.geom.builder.DSL.g;
 import static org.geolatte.geom.builder.DSL.ring;
+import static org.geolatte.geom.builder.DSL.linestring;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/geom/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
+++ b/geom/src/test/java/org/geolatte/geom/cga/NumericalMethodsTest.java
@@ -126,7 +126,7 @@ public class NumericalMethodsTest {
     }
 
     @Test
-    public void testCounterClockwiseLineString() throws ParseException {
+    public void testCounterClockwiseLineString() {
         LineString<G2D> cwLinestring  = linestring(wgs84, g(3, 51), g(4, 51), g(5, 51.5), g(4, 50),   g(3, 51));
         LineString<G2D> ccwLinestring = linestring(wgs84, g(3, 51), g(4, 51), g(5, 51.5), g(4, 51.5), g(3, 51));
 


### PR DESCRIPTION
This fixes the algorithm to work as documented.

It seems that with commit 7773d90 the logic broke. Note that the commit-comment doesn't match javadoc. Due to 'det == 0' in while-condition, the loop was only executed once.

Added a test to demonstrate the fix.