### PR TITLE
Performance improvements in ByteBuffer.from()

### DIFF
--- a/geom/src/test/java/org/geolatte/geom/codec/TestByteBuffer.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/TestByteBuffer.java
@@ -85,6 +85,17 @@ public class TestByteBuffer {
         }
     }
 
+    @Test
+    public void test_negative_byte() {
+        ByteBuffer bb = ByteBuffer.from("-A");
+        assertEquals(-10, bb.get());
+    }
+
+    @Test
+    public void test_positive_byte() {
+        ByteBuffer bb = ByteBuffer.from("+A");
+        assertEquals(10, bb.get());
+    }
 
     @Test
     public void test_toString() {

--- a/geom/src/test/java/org/geolatte/geom/codec/TestByteBufferInvalidCharacters.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/TestByteBufferInvalidCharacters.java
@@ -1,0 +1,49 @@
+package org.geolatte.geom.codec;
+
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.geolatte.geom.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestByteBufferInvalidCharacters {
+
+  @Parameters
+  public static Collection<Object[]> charactersToTest() {
+    List<Object[]> characters = new ArrayList<>();
+    for (char i = 0; i < 256; ++i) {
+      if ((i >= 'A' && i <= 'F')
+          || (i >= 'a' && i <= 'f')
+          || (i >= '0' && i <= '9')
+          || i == '+' || i == '-'
+      ) {
+        continue;
+      }
+      characters.add(new Object[]{i});
+    }
+    return characters;
+  }
+
+  private final char characterToTest;
+
+  public TestByteBufferInvalidCharacters(char characterToTest) {
+    this.characterToTest = characterToTest;
+  }
+
+  @Test(expected = NumberFormatException.class)
+  public void testThatNumberFormatExceptionIsThrown() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(characterToTest);
+    sb.append("0");
+    ByteBuffer.from(sb.toString());
+    fail("string " + sb.toString() + " should trigger a number format exception. characterToTest="
+        + (int) characterToTest);
+  }
+
+}


### PR DESCRIPTION
During a profiling session using Hibernate and Postgres, ByteBuffer.from(hexString) popped at the top of the slow functions.

After looking at the function, it appeared, that splitting the string is quite time and memory intense.

This patch implements a conversion from characters using only integer math, some bit shifting and so on. It tries to be as much compliant to the Integer.parse(string, radix) function, as used prior in order to keep the behaviour of the API stable. Therefore also some extra unit tests.

Tests with a 10k long string in a loop of 100k times showed that it could be converted in around 2.4s whereas the original implementation took around 20s.