### PR TITLE
Enforce JTS 1.16.0 minimally

### DIFF
--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>org.locationtech.jts</groupId>
 			<artifactId>jts-core</artifactId>
-			<version>1.16.0</version>
+			<version>[1.16.0,)</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
As JTS is a transitive dependency for most projects, the version number preference is not always enforced. So with multiple dependencies depending on JTS (in my case a dependency on [bedatadriven/jackson-datatype-jts](https://github.com/bedatadriven/jackson-datatype-jts)), one might end up with an older version of JTS. Because GeoLatte is dependent on the availability of `CoordinateXY`, which was [introduced in JTS `1.16.0`](https://github.com/locationtech/jts/blob/master/modules/core/src/main/java/org/locationtech/jts/geom/CoordinateXY.java), we need JTS `1.16.0` minimally. Declaring this requirement in the `pom.xml` file might help Maven to select the right version of JTS or at least help users facing similar issues find resolve quicker.

Relevant portion of the stack trace demonstrating the problem:

```

java.lang.ClassNotFoundException: org.locationtech.jts.geom.CoordinateXY
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382) ~[na:1.8.0_211]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424) ~[na:1.8.0_211]
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349) ~[na:1.8.0_211]
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ~[na:1.8.0_211]
	at org.geolatte.geom.FixedSizePositionSequenceBuilder.toPositionSequence(FixedSizePositionSequenceBuilder.java:53) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.readPositions(AbstractWkbDecoder.java:155) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.readRing(AbstractWkbDecoder.java:174) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.readPolygonRings(AbstractWkbDecoder.java:167) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodePolygon(AbstractWkbDecoder.java:133) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodeGeometry(AbstractWkbDecoder.java:69) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodeMultiPolygon(AbstractWkbDecoder.java:113) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodeGeometry(AbstractWkbDecoder.java:75) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodeGeometryCollection(AbstractWkbDecoder.java:126) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decodeGeometry(AbstractWkbDecoder.java:71) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decode(AbstractWkbDecoder.java:45) ~[geolatte-geom-1.4.0.jar:na]
	at org.geolatte.geom.codec.AbstractWkbDecoder.decode(AbstractWkbDecoder.java:55) ~[geolatte-geom-1.4.0.jar:na]
	at org.hibernate.spatial.dialect.postgis.PGGeometryTypeDescriptor.toGeometry(PGGeometryTypeDescriptor.java:59) ~[hibernate-spatial-5.4.3.Final.jar:5.4.3.Final]
	at org.hibernate.spatial.dialect.postgis.PGGeometryTypeDescriptor$2.doExtract(PGGeometryTypeDescriptor.java:121) ~[hibernate-spatial-5.4.3.Final.jar:5.4.3.Final]
```