### PR TITLE
Fix thread safety issues in a multi threaded environment.

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/Decoders.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/Decoders.java
@@ -4,36 +4,15 @@ import org.geolatte.geom.Geometry;
 import org.geolatte.geom.codec.db.Decoder;
 
 import java.sql.Struct;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 19/03/15.
  */
 public class Decoders {
 
-    final private static List<AbstractSDODecoder> DECODERS = new ArrayList<AbstractSDODecoder>();
-
-    static {
-        //Decoders
-        DECODERS.add( new PointSdoDecoder() );
-        DECODERS.add( new LineStringSdoDecoder() );
-        DECODERS.add( new PolygonSdoDecoder() );
-        DECODERS.add( new MultiLineSdoDecoder(  ) );
-        DECODERS.add( new MultiPolygonSdoDecoder(  ) );
-        DECODERS.add( new MultiPointSdoDecoder( ) );
-        DECODERS.add( new GeometryCollectionSdoDecoder(  ) );
-    }
-
-
-    public static Decoder decoderFor(SDOGeometry object) {
-        for ( Decoder decoder : DECODERS ) {
-            if ( decoder.accepts( object ) ) {
-                return decoder;
-            }
-        }
-        throw new IllegalArgumentException( "No decoder for type " + object.getGType().getTypeGeometry() );
-    }
+	public static Decoder decoderFor(SDOGeometry object) {
+		return object.getGType().getTypeGeometry().createDecoder();
+	}
 
     /**
      * Decodes the SQL Server Geometry object to its JTS Geometry instance

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/TypeGeometry.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/TypeGeometry.java
@@ -21,15 +21,74 @@
 
 package org.geolatte.geom.codec.db.oracle;
 
+import org.geolatte.geom.codec.db.Decoder;
+
 /**
  * @author Karel Maesen, Geovise BVBA
  *         creation-date: Jul 1, 2010
  */
 enum TypeGeometry {
 
-	UNKNOWN_GEOMETRY( 0 ), POINT( 1 ), LINE( 2 ), POLYGON( 3 ), COLLECTION( 4 ), MULTIPOINT(
-			5
-	), MULTILINE( 6 ), MULTIPOLYGON( 7 ), SOLID( 8 ), MULTISOLID( 9 );
+	UNKNOWN_GEOMETRY(0) {
+		@Override
+		Decoder createDecoder() {
+			throw new UnsupportedOperationException();
+		}
+	},
+	POINT(1) {
+		@Override
+		Decoder createDecoder() {
+			return new PointSdoDecoder();
+		}
+	},
+	LINE(2) {
+		@Override
+		Decoder createDecoder() {
+			return new LineStringSdoDecoder();
+		}
+	},
+	POLYGON(3) {
+		@Override
+		Decoder createDecoder() {
+			return new PolygonSdoDecoder();
+		}
+	},
+	COLLECTION(4) {
+		@Override
+		Decoder createDecoder() {
+			return new GeometryCollectionSdoDecoder();
+		}
+	},
+	MULTIPOINT(5) {
+		@Override
+		Decoder createDecoder() {
+			return new MultiPointSdoDecoder();
+		}
+	},
+	MULTILINE(6) {
+		@Override
+		Decoder createDecoder() {
+			return new MultiLineSdoDecoder();
+		}
+	},
+	MULTIPOLYGON(7) {
+		@Override
+		Decoder createDecoder() {
+			return new MultiPolygonSdoDecoder();
+		}
+	},
+	SOLID(8) {
+		@Override
+		Decoder createDecoder() {
+			throw new UnsupportedOperationException();
+		}
+	},
+	MULTISOLID(9) {
+		@Override
+		Decoder createDecoder() {
+			throw new UnsupportedOperationException();
+		}
+	};
 
 	private int gtype;
 
@@ -53,4 +112,5 @@ enum TypeGeometry {
 		);
 	}
 
+	abstract Decoder createDecoder();
 }


### PR DESCRIPTION
Fix for https://github.com/GeoLatte/geolatte-geom/issues/121

I tried to reason why you would want to use a static list of decoders. I don't think it's for performance reasons right?
To mitigate the multithreading issue I moved away from static/singleton decoders and replaced it with an enum factory.