### PR TITLE
Fix for parsing of GEOMETRYCOLLECTION with MULTIPOINT (Oracle).

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ElemInfoTriplet.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ElemInfoTriplet.java
@@ -19,7 +19,7 @@ abstract class ElemInfoTriplet {
         int interp = triplet[2].intValue();
         ElementType et = ElementType.parseType(etype, interp);
         if (et.isCompound()) {
-            return new CompoundIElemInfoTriplet(sOffset, et);
+            return new CompoundIElemInfoTriplet(sOffset, et, interp);
         } else {
             return new SimpleIElemInfoTriplet(sOffset, et);
         }
@@ -44,6 +44,8 @@ abstract class ElemInfoTriplet {
 
     abstract boolean isCompound();
 
+    abstract int getInterpretation();
+
     ElementType getElementType() {
         return elementType;
     }
@@ -53,7 +55,7 @@ abstract class ElemInfoTriplet {
     void addTo(List<BigDecimal> list) {
         list.add(BigDecimal.valueOf(startingOffset));
         list.add(BigDecimal.valueOf(elementType.getEType()));
-        list.add(BigDecimal.valueOf(elementType.getInterpretation()));
+        list.add(BigDecimal.valueOf(getInterpretation()));
     }
 
 }
@@ -74,6 +76,11 @@ class SimpleIElemInfoTriplet extends ElemInfoTriplet {
         return false;
     }
 
+    @Override
+    int getInterpretation() {
+        return this.getElementType().getInterpretation();
+    }
+
     ElemInfoTriplet shiftStartingOffset(int offset) {
         return new SimpleIElemInfoTriplet(this.getStartingOffset() + offset, this.getElementType());
     }
@@ -82,8 +89,11 @@ class SimpleIElemInfoTriplet extends ElemInfoTriplet {
 
 class CompoundIElemInfoTriplet extends ElemInfoTriplet {
 
-    CompoundIElemInfoTriplet(int sOffset, ElementType et) {
+    private final int numParts;
+
+    CompoundIElemInfoTriplet(int sOffset, ElementType et, int numParts) {
         super(sOffset, et);
+        this.numParts = numParts;
     }
 
     @Override
@@ -97,10 +107,15 @@ class CompoundIElemInfoTriplet extends ElemInfoTriplet {
     }
 
     int numParts() {
-        return getElementType().getInterpretation();
+        return this.numParts;
+    }
+
+    @Override
+    int getInterpretation() {
+        return this.numParts;
     }
 
     ElemInfoTriplet shiftStartingOffset(int offset) {
-        return new CompoundIElemInfoTriplet(this.getStartingOffset() + offset, this.getElementType());
+        return new CompoundIElemInfoTriplet(this.getStartingOffset() + offset, this.getElementType(), this.numParts);
     }
 }

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ElementType.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ElementType.java
@@ -29,7 +29,7 @@ enum ElementType {
     UNSUPPORTED(0, true),
     POINT(1, 1),
     ORIENTATION(1, 0),
-    POINT_CLUSTER(1, false),
+    POINT_CLUSTER(1, true),
     LINE_STRAITH_SEGMENTS(2, 1),
     LINE_ARC_SEGMENTS(2, 2),
     INTERIOR_RING_STRAIGHT_SEGMENTS(2003, 1),

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/SDOGeometry.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/SDOGeometry.java
@@ -155,7 +155,7 @@ public class SDOGeometry {
         int cnt = 0;
         int i = 0;
         while (i < info.getSize()) {
-            if (info.getElementType(i).isCompound()) {
+            if (info.getElementType(i).isCompound() && info.getElementType(i) != ElementType.POINT_CLUSTER) {
                 final int numCompounds = info.getNumCompounds(i);
                 i += 1 + numCompounds;
             } else {
@@ -248,7 +248,7 @@ public class SDOGeometry {
                 }
                 next++;
             }
-        } else if (elemInfo.isCompound()) {
+        } else if (elemInfo.isCompound() && et.getEType() != 1) {
             next = i + ((CompoundIElemInfoTriplet) elemInfo).numParts() + 1;
         }
         return next;

--- a/geom/src/test/java/org/geolatte/geom/codec/db/oracle/TestSdoGeometryGeometryCollectionDecoder.java
+++ b/geom/src/test/java/org/geolatte/geom/codec/db/oracle/TestSdoGeometryGeometryCollectionDecoder.java
@@ -1,16 +1,12 @@
 package org.geolatte.geom.codec.db.oracle;
 
-import org.geolatte.geom.G2D;
-import org.geolatte.geom.Geometry;
-import org.geolatte.geom.AbstractGeometryCollection;
+import org.geolatte.geom.*;
 import org.geolatte.geom.crs.CrsRegistry;
 import org.geolatte.geom.crs.GeographicCoordinateReferenceSystem;
+import org.junit.Test;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.junit.Assert.assertEquals;
-
-import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 01/04/15.
@@ -32,4 +28,24 @@ public class TestSdoGeometryGeometryCollectionDecoder {
         assertEquals(geom, Decoders.decode(sdo));
     }
 
+    @Test
+    public void testComplexGeometryCollection() {
+        SDOGeometry sdo = SDOGeometryHelper.sdoGeometry(2004, 4326, null, new int[]{ 1, 1, 1, 3, 1, 3, 9, 1003, 1, 19, 2003, 1} ,
+                new Double[]{10.,5.,10.,10.,20.,10.,20.,10.,0.,0.,50.,0.,100.,100.,0.,100.,0.,0.,1.,1.,49.,1.,99.,99.,1.,99.,1.,1.});
+
+        AbstractGeometryCollection<G2D, Geometry<G2D>> geom =
+                geometrycollection(wgs84,
+                        point(g(10, 5)),
+                        multipoint(point(g(10, 10)), point(g(20, 10)), point(g(20, 10))),
+                        polygon(
+                                ring(g(0, 0), g(50, 0), g(100, 100), g(0, 100), g(0, 0)),
+                                ring(g(1, 1), g(49, 1), g(99, 99), g(1, 99), g(1, 1))));
+
+        GeometryCollection decodedGeometry = (GeometryCollection) Decoders.decode(sdo);
+        assertEquals(geom, decodedGeometry);
+        assertEquals(decodedGeometry.getGeometryN(1).getGeometryType(), GeometryType.MULTIPOINT);
+        assertEquals(((MultiPoint) decodedGeometry.getGeometryN(1)).getNumGeometries(), 3);
+    }
 }
+
+//(2005,0,null,(1,1,9),(210921.03,638080.97,210919.92,638274.15,210924.77,638056.98,210929.6,638283.58,210926.94,638271.23,210930.11,637940.3,210963.71,638468.55,210955.13,637928.58,210983.74,638504.63))


### PR DESCRIPTION
PR for issue #140 

According to https://docs.oracle.com/database/121/SPATL/sdo_geometry-object-type.htm#GUID-270AE39D-7B83-46D0-9DD6-E5D99C045021__BGHDGCCE, SDO_INTERPRETATION with MULTIPOINT (cluster) describe how many points we'll have in MULTI geometry.

To get it work properly I had to set POINT_CLUSTER as compound geometry and add internal variable in CompoundIElemInfoTriplet. 

To be honest, I'm not sure that changes in CompoundIElemInfoTriplet:numParts() and CompoundIElemInfoTriplet:getInterpretation() are ok, even though all test are passing.

Last change is adding small and simple test for such geometries.

Let me know if I should do anything more with it.