### PR TITLE
Unwrap Oracle connection if it can

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ConnectionFinder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/ConnectionFinder.java
@@ -45,7 +45,7 @@ public interface ConnectionFinder extends Serializable {
      *
      * @param conn the object that is being searched for an OracleConnection
      * @return the object sought
-     * @throws RuntimeException thrown when the feature can be found;
+     * @throws RuntimeException thrown when the feature cannot be found;
      */
     Connection find(Connection conn);
 

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/DefaultConnectionFinder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/DefaultConnectionFinder.java
@@ -67,7 +67,8 @@ public class DefaultConnectionFinder implements ConnectionFinder {
             if (con.isWrapperFor(ORACLE_CONNECTION_INTERFACE)) {
                 return (Connection) con.unwrap(ORACLE_CONNECTION_INTERFACE);
             }
-        } catch (SQLException e1) {
+        } catch (SQLException e) {
+            // Unwrapping failed, falling back on reflection
         }
 
         // try to find the Oracleconnection recursively

--- a/geom/src/main/java/org/geolatte/geom/codec/db/oracle/DefaultConnectionFinder.java
+++ b/geom/src/main/java/org/geolatte/geom/codec/db/oracle/DefaultConnectionFinder.java
@@ -24,6 +24,7 @@ package org.geolatte.geom.codec.db.oracle;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * Default <code>ConnectionFinder</code> implementation.
@@ -41,10 +42,12 @@ import java.sql.Connection;
 public class DefaultConnectionFinder implements ConnectionFinder {
 
     private static final Class<?> ORACLE_CONNECTION_CLASS;
+    private static final Class<?> ORACLE_CONNECTION_INTERFACE;
 
     static {
         try {
             ORACLE_CONNECTION_CLASS = Class.forName("oracle.jdbc.driver.OracleConnection");
+            ORACLE_CONNECTION_INTERFACE = Class.forName("oracle.jdbc.OracleConnection");
         } catch (ClassNotFoundException e) {
             throw new RuntimeException("Can't find Oracle JDBC Driver on classpath.");
         }
@@ -59,6 +62,14 @@ public class DefaultConnectionFinder implements ConnectionFinder {
         if (ORACLE_CONNECTION_CLASS.isInstance(con)) {
             return con;
         }
+
+        try {
+            if (con.isWrapperFor(ORACLE_CONNECTION_INTERFACE)) {
+                return (Connection) con.unwrap(ORACLE_CONNECTION_INTERFACE);
+            }
+        } catch (SQLException e1) {
+        }
+
         // try to find the Oracleconnection recursively
         for (Method method : con.getClass().getMethods()) {
             if (java.sql.Connection.class.isAssignableFrom(


### PR DESCRIPTION
In my application I have a `io.agroal.pool.wrapper.ConnectionWrapper` which wraps an Oracle connection. The `DefaultConnectionFinder` can't find the Oracle connection because the wrapper doesn't have a getter that returns the Oracle connection. It does however have the `unwrap()` method which return the Oracle connection. So try to use that before falling back on reflection.