### PR TITLE
Fix npe comparing empty points

### DIFF
--- a/geom/src/main/java/org/geolatte/geom/jts/JTSUtils.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/JTSUtils.java
@@ -1,7 +1,6 @@
 package org.geolatte.geom.jts;
 
 
-import org.geolatte.geom.Simple;
 import org.locationtech.jts.geom.*;
 
 /**
@@ -58,6 +57,16 @@ public class JTSUtils {
                 ((Double.isNaN(c1.getM()) && Double.isNaN(c2.getM())) || c1.getM() == c2.getM());
     }
 
+    private static boolean equalPoints(Point p1, Point p2) {
+        if (p1.isEmpty() != p2.isEmpty()) {
+            return false;
+        }
+        if (p1.isEmpty() && p2.isEmpty()) {
+            return true;
+        }
+        return equals3D(p1.getCoordinate(), p2.getCoordinate());
+    }
+
     private static boolean equalLineStringCoordinates(LineString g1, LineString g2) {
         int np1 = g1.getNumPoints();
         int np2 = g2.getNumPoints();
@@ -86,7 +95,7 @@ public class JTSUtils {
         //this method assumes that g1 and g2 are of the same type
         assert (g1.getClass().equals(g2.getClass()));
         if (g1 instanceof Point) {
-            return equals3D(g1.getCoordinate(), g2.getCoordinate());
+            return equalPoints((Point) g1, (Point) g2);
         }
 
         if (g1 instanceof LineString) {

--- a/geom/src/test/java/org/geolatte/geom/jts/JTSUtilsTest.java
+++ b/geom/src/test/java/org/geolatte/geom/jts/JTSUtilsTest.java
@@ -50,6 +50,13 @@ public class JTSUtilsTest {
     }
 
     @Test
+    public void testEmptyPointDoesntEqualRealPoint() {
+        Geometry pn1 = JTS.to(point(WGS84));
+        Geometry pn2 = JTS.to(point(WGS84, g(3, 50)));
+        assertFalse(equalsExact3D(pn1, pn2));
+    }
+
+    @Test
     public void testEqualsPointsAreEqual() {
         Point pnt1 = (Point) JTS.to(point(WGS84, g(3, 50)));
         Point pnt2 = (Point) JTS.to(point(WGS84, g(3, 50)));


### PR DESCRIPTION
I was encountering the following NPE when used with Hibernate/Spring Boot 3, which is being caused by a `POINT EMPTY` being passed as one of the parameters.
```
java.lang.NullPointerException: Cannot read field "x" because "c1" is null
	at org.geolatte.geom.jts.JTSUtils.equals3D(JTSUtils.java:56)
	at org.geolatte.geom.jts.JTSUtils.equals3DPrimitiveGeometries(JTSUtils.java:89)
	at org.geolatte.geom.jts.JTSUtils.equalsExact3D(JTSUtils.java:43)
```

Given this seems like valid input, I've put in some handling for this case, including a unit test.
