### PR TITLE
PointSequenceCoordinateSequenceFactory must keep the M-coordinates

### DIFF
--- a/geom/pom.xml
+++ b/geom/pom.xml
@@ -73,6 +73,20 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-main</artifactId>
+			<version>32.2</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-epsg-hsql</artifactId>
+			<version>32.2</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
+++ b/geom/src/main/java/org/geolatte/geom/jts/PointSequenceCoordinateSequenceFactory.java
@@ -65,6 +65,23 @@ class PointSequenceCoordinateSequenceFactory implements CoordinateSequenceFactor
         return new CoordinateArraySequence(size, dimension);
     }
 
+    @Override
+    public CoordinateSequence create(int size, int dimension, int measures) {
+        int spatial = dimension - measures;
+        if (measures > 1) {
+            measures = 1;
+        }
+
+        if (spatial > 3) {
+            spatial = 3;
+        }
+
+        if (spatial < 2) {
+            spatial = 2;
+        }
+        return new CoordinateArraySequence(size, spatial + measures, measures);
+    }
+
     @SuppressWarnings("unchecked")
     public <P extends Position> PositionSequence<P> toPositionSequence(CoordinateSequence cs, Class<P> posType,
                                                                        CoordinateReferenceSystem<P> crs) {


### PR DESCRIPTION
The default implementation of the create method that supports geometry measures (M-coordinates) in PointSequenceCoordinateSequenceFactory doesn't provide the CoordinateSequence dimension to store the measures in the resulting geometry. Als a result, all M-coordinates provided to the factory are lost. Another side-effect of this bug is that the Z-coordinates are also lost. 