### PR TITLE
Updated to Jackson 3.

### DIFF
--- a/json/README.md
+++ b/json/README.md
@@ -4,6 +4,8 @@
 
 # GeoJson module
 
+Updated to Jackson 3.x.
+
 This modules provides a Jackson module to (de)serialize `Geometry`, `Feature` and `FeatureCollection` instances to 
 (from) GeoJson.
 

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -19,9 +19,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0-rc1</version>
+            <version>3.0.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/json/src/main/java/org/geolatte/geom/json/BoxSerializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/BoxSerializer.java
@@ -1,24 +1,23 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import org.geolatte.geom.Box;
 import org.geolatte.geom.Position;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-import java.io.IOException;
 import java.util.Arrays;
 
-public class BoxSerializer<P extends Position> extends JsonSerializer<Box<P>> {
+public class BoxSerializer<P extends Position> extends ValueSerializer<Box<P>> {
 
     @Override
-    public void serialize(Box<P> box, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Box<P> box, JsonGenerator gen, SerializationContext serializers) {
         final double[] bbox = concat(box.lowerLeft().toArray(null), box.upperRight().toArray(null));
         gen.writeArray(bbox, 0, bbox.length);
     }
 
     @Override
-    public boolean isEmpty(SerializerProvider provider, Box<P> box) {
+    public boolean isEmpty(SerializationContext provider, Box<P> box) {
         return box == null || box.isEmpty();
     }
 

--- a/json/src/main/java/org/geolatte/geom/json/CrsDeserializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/CrsDeserializer.java
@@ -1,18 +1,15 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.geolatte.geom.crs.CrsId;
 import org.geolatte.geom.crs.CrsRegistry;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-import java.io.IOException;
-
-public class CrsDeserializer extends JsonDeserializer<CoordinateReferenceSystem> {
+public class CrsDeserializer extends ValueDeserializer<CoordinateReferenceSystem> {
 
     final private CoordinateReferenceSystem<?> defaultCrs;
     final private Settings settings;
@@ -22,13 +19,12 @@ public class CrsDeserializer extends JsonDeserializer<CoordinateReferenceSystem>
         this.settings = settings;
     }
 
-    private JsonNode getRoot(JsonParser p) throws IOException, GeoJsonProcessingException {
-        ObjectCodec oc = p.getCodec();
-        return oc.readTree(p);
+    private JsonNode getRoot(JsonParser p) throws JacksonException {
+        return p.readValueAsTree();
     }
 
     @Override
-    public CoordinateReferenceSystem<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public CoordinateReferenceSystem<?> deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
         JsonNode root = getRoot(p);
         return resolveBaseCrs(root);
     }

--- a/json/src/main/java/org/geolatte/geom/json/CrsSerializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/CrsSerializer.java
@@ -1,14 +1,12 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import org.geolatte.geom.Position;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-import java.io.IOException;
-
-public class CrsSerializer<P extends Position> extends JsonSerializer<CoordinateReferenceSystem<P>> {
+public class CrsSerializer<P extends Position> extends ValueSerializer<CoordinateReferenceSystem<P>> {
 
     final private CoordinateReferenceSystem<P> defaultCRS;
     final private Settings settings;
@@ -19,18 +17,18 @@ public class CrsSerializer<P extends Position> extends JsonSerializer<Coordinate
     }
 
     @Override
-    public void serialize(CoordinateReferenceSystem<P> crs, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(CoordinateReferenceSystem<P> crs, JsonGenerator gen, SerializationContext serializers) {
         writeCrs(gen, crs);
     }
 
-    private void writeCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) throws IOException {
+    private void writeCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) {
         writeNamedCrs(gen, crs);
     }
 
-    private void writeNamedCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) throws IOException {
+    private void writeNamedCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) {
         gen.writeStartObject();
-        gen.writeStringField("type", "name");
-        gen.writeFieldName("properties");
+        gen.writeStringProperty("type", "name");
+        gen.writeName("properties");
         if (settings.isSet(Setting.SERIALIZE_CRS_AS_URN)) {
             writeCrsName(gen, crs.getCrsId().toUrn());
         } else {
@@ -39,9 +37,9 @@ public class CrsSerializer<P extends Position> extends JsonSerializer<Coordinate
         gen.writeEndObject();
     }
 
-    private void writeCrsName(JsonGenerator gen, String epsgString) throws IOException {
+    private void writeCrsName(JsonGenerator gen, String epsgString) {
         gen.writeStartObject();
-        gen.writeStringField("name", epsgString);
+        gen.writeStringProperty("name", epsgString);
         gen.writeEndObject();
     }
 }

--- a/json/src/main/java/org/geolatte/geom/json/FeatureCollectionDeserializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/FeatureCollectionDeserializer.java
@@ -1,22 +1,18 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.geolatte.geom.Feature;
 import org.geolatte.geom.FeatureCollection;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
-
 @SuppressWarnings("rawtypes")
-public class FeatureCollectionDeserializer extends JsonDeserializer<FeatureCollection> {
+public class FeatureCollectionDeserializer extends ValueDeserializer<FeatureCollection> {
     final private FeatureDeserializer fDeserializer;
     public FeatureCollectionDeserializer(CoordinateReferenceSystem<?> defaultCrs, Settings settings) {
         this.fDeserializer = new FeatureDeserializer(defaultCrs, settings);
@@ -24,14 +20,12 @@ public class FeatureCollectionDeserializer extends JsonDeserializer<FeatureColle
 
     @Override
     @SuppressWarnings("unchecked")
-    public FeatureCollection<?, ?> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-        ObjectCodec oc = jsonParser.getCodec();
-        JsonNode root = oc.readTree(jsonParser);
+    public FeatureCollection<?, ?> deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
+        JsonNode root = jsonParser.readValueAsTree();
         JsonNode featureNds = root.get("features");
         List<Feature<?, ?>> features = new ArrayList<>();
-        for (Iterator<JsonNode> it = featureNds.elements(); it.hasNext(); ) {
-            JsonNode fNode = it.next();
-            features.add(fDeserializer.readFeature(oc, fNode));
+        for (JsonNode feature : featureNds) {
+            features.add(fDeserializer.readFeature(jsonParser, feature));
         }
         return (GeoJsonFeatureCollection<?,?>)new GeoJsonFeatureCollection(features);
     }

--- a/json/src/main/java/org/geolatte/geom/json/FeatureCollectionSerializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/FeatureCollectionSerializer.java
@@ -1,16 +1,14 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import org.geolatte.geom.Box;
 import org.geolatte.geom.Feature;
 import org.geolatte.geom.FeatureCollection;
 import org.geolatte.geom.Position;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-import java.io.IOException;
-
-public class FeatureCollectionSerializer<P extends Position, ID> extends JsonSerializer<FeatureCollection<P, ID>> {
+public class FeatureCollectionSerializer<P extends Position, ID> extends ValueSerializer<FeatureCollection<P, ID>> {
 
     private final Settings settings;
 
@@ -19,20 +17,18 @@ public class FeatureCollectionSerializer<P extends Position, ID> extends JsonSer
     }
 
     @Override
-    public void serialize(FeatureCollection<P, ID> featureColl, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
+    public void serialize(FeatureCollection<P, ID> featureColl, JsonGenerator gen, SerializationContext serializers) {
         gen.writeStartObject();
-        gen.writeStringField("type", FeatureCollection.TYPE);
+        gen.writeStringProperty("type", FeatureCollection.TYPE);
         Box<?> box = featureColl.getBbox();
         if (box != null && !box.isEmpty() && settings.isSet(Setting.SERIALIZE_FEATURE_COLLECTION_BBOX)) {
-            gen.writeFieldName("bbox");
-            gen.writeObject(featureColl.getBbox());
+            gen.writePOJOProperty("bbox", box);
         }
-        gen.writeArrayFieldStart("features");
+        gen.writeArrayPropertyStart("features");
         for (Feature<?, ?> f : featureColl.getFeatures()) {
-            gen.writeObject(f);
+            gen.writePOJO(f);
         }
         gen.writeEndArray();
         gen.writeEndObject();
-
     }
 }

--- a/json/src/main/java/org/geolatte/geom/json/FeatureDeserializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/FeatureDeserializer.java
@@ -1,20 +1,20 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.*;
 import org.geolatte.geom.Feature;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 13/07/2018.
  */
-public class FeatureDeserializer extends JsonDeserializer<Feature> {
+public class FeatureDeserializer extends ValueDeserializer<Feature> {
 
     final private CoordinateReferenceSystem<?> defaultCrs;
     final private Settings settings;
@@ -27,14 +27,12 @@ public class FeatureDeserializer extends JsonDeserializer<Feature> {
     }
 
     @Override
-    public Feature<?,?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
-
-        ObjectCodec oc = p.getCodec();
-        JsonNode root = oc.readTree(p);
-        return readFeature(oc, root);
+    public Feature<?,?> deserialize(JsonParser p, DeserializationContext ctxt) throws JacksonException {
+        JsonNode root = p.readValueAsTree();
+        return readFeature(p, root);
     }
 
-    GeoJsonFeature<?, Object> readFeature(ObjectCodec oc, JsonNode root) throws JsonProcessingException {
+    GeoJsonFeature<?, Object> readFeature(JsonParser p, JsonNode root) throws JacksonException {
         JsonNode geomNode = root.get("geometry");
         Geometry<?> geom = (null == geomNode || geomNode.isNull()) ? null : geomParser.parseGeometry(geomNode);
 
@@ -47,10 +45,24 @@ public class FeatureDeserializer extends JsonDeserializer<Feature> {
                 id = idNode.asText();
             }
         }
-        HashMap<String, Object> properties =  (HashMap<String, Object>) oc.treeToValue(root.get("properties"), HashMap.class);
+
+        HashMap<String, Object> properties = new HashMap<>();
+        JsonNode propNode = root.get("properties");
+        if(propNode != null) {
+            for (String property: propNode.propertyNames()) {
+                Object value = null;
+                JsonNode valueNode = propNode.get(property);
+                if (valueNode == null) continue;
+
+                if (valueNode.canConvertToInt()) {
+                    value = valueNode.asInt();
+                } else {
+                    value = valueNode.asText();
+                }
+                properties.put(property, value);
+            }
+        }
 
         return new GeoJsonFeature<>(geom, id, properties);
     }
-
-
 }

--- a/json/src/main/java/org/geolatte/geom/json/FeatureSerializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/FeatureSerializer.java
@@ -1,15 +1,13 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
 import org.geolatte.geom.Box;
 import org.geolatte.geom.Feature;
 import org.geolatte.geom.Position;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
 
-import java.io.IOException;
-
-public class FeatureSerializer<P extends Position, ID> extends JsonSerializer<Feature<P, ID>> {
+public class FeatureSerializer<P extends Position, ID> extends ValueSerializer<Feature<P, ID>> {
 
     private final Settings settings;
 
@@ -18,22 +16,18 @@ public class FeatureSerializer<P extends Position, ID> extends JsonSerializer<Fe
     }
 
     @Override
-    public void serialize(Feature<P, ID> feature, JsonGenerator gen, SerializerProvider serializerProvider) throws IOException {
+    public void serialize(Feature<P, ID> feature, JsonGenerator gen, SerializationContext serializers) {
         gen.writeStartObject();
-        gen.writeStringField("type", Feature.TYPE);
+        gen.writeStringProperty("type", Feature.TYPE);
         if (feature.getId() != null) {
-            gen.writeFieldName("id");
-            gen.writeObject(feature.getId());
+            gen.writePOJOProperty("id", feature.getId());
         }
         Box<?> box = feature.getBbox();
         if (box != null && !box.isEmpty() && settings.isSet(Setting.SERIALIZE_FEATURE_BBOX)) {
-            gen.writeFieldName("bbox");
-            gen.writeObject(box);
+            gen.writePOJOProperty("bbox", box);
         }
-        gen.writeFieldName("geometry");
-        gen.writeObject(feature.getGeometry());
-        gen.writeFieldName("properties");
-        gen.writeObject(feature.getProperties());
+        gen.writePOJOProperty("geometry", feature.getGeometry());
+        gen.writePOJOProperty("properties", feature.getProperties());
         gen.writeEndObject();
     }
 }

--- a/json/src/main/java/org/geolatte/geom/json/GeoJsonFeature.java
+++ b/json/src/main/java/org/geolatte/geom/json/GeoJsonFeature.java
@@ -16,7 +16,6 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
  */
 public class GeoJsonFeature<P extends Position, ID> implements Feature<P, ID> {
 
-
     final private Geometry<P> geometry;
 
     final private ID id;
@@ -73,4 +72,3 @@ public class GeoJsonFeature<P extends Position, ID> implements Feature<P, ID> {
                 '}';
     }
 }
-

--- a/json/src/main/java/org/geolatte/geom/json/GeoJsonProcessingException.java
+++ b/json/src/main/java/org/geolatte/geom/json/GeoJsonProcessingException.java
@@ -1,11 +1,11 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 08/09/17.
  */
-public class GeoJsonProcessingException extends JsonProcessingException {
+public class GeoJsonProcessingException extends JacksonException {
 
     GeoJsonProcessingException(String msg) {
         super(msg);

--- a/json/src/main/java/org/geolatte/geom/json/GeolatteGeomModule.java
+++ b/json/src/main/java/org/geolatte/geom/json/GeolatteGeomModule.java
@@ -1,10 +1,10 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.Version;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import org.geolatte.geom.*;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
+import tools.jackson.core.Version;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ValueDeserializer;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,10 +20,9 @@ import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
 @SuppressWarnings("rawtypes")
 public class GeolatteGeomModule extends SimpleModule {
 
-
     private final Settings settings = new Settings();
 
-    private final Map<Class, JsonDeserializer> dezers = new HashMap<>();
+    private final Map<Class, ValueDeserializer> dezers = new HashMap<>();
 
     private final GeometrySerializer geometrySerializer;
     private final CrsSerializer crsSerializer;
@@ -35,7 +34,7 @@ public class GeolatteGeomModule extends SimpleModule {
     @SuppressWarnings("unchecked")
     public <P extends Position> GeolatteGeomModule(CoordinateReferenceSystem<P> defaultCrs) {
 
-        super("GeolatteGeomModule", new Version(1, 9, 0, "", "org.geolatte", "geolatte-json"));
+        super("GeolatteGeomModule", new Version(2, 0, 0, "", "org.geolatte", "geolatte-json"));
 
         geometrySerializer = new GeometrySerializer(settings);
         FeatureSerializer featureSerializer = new FeatureSerializer(settings);
@@ -67,7 +66,6 @@ public class GeolatteGeomModule extends SimpleModule {
         settings.override(setting, value);
     }
 
-
     public GeometrySerializer getGeometrySerializer() {
         return this.geometrySerializer;
     }
@@ -77,15 +75,13 @@ public class GeolatteGeomModule extends SimpleModule {
      * <p>
      * This method is provided for interoperability reasons
      */
-    public Map<Class, JsonDeserializer> getGeometryDeserializers() {
+    public Map<Class, ValueDeserializer> getGeometryDeserializers() {
         return unmodifiableMap(dezers);
     }
-
 
     public void copyToModule(SimpleModule other) {
         other.addSerializer(getGeometrySerializer());
         other.addSerializer(this.crsSerializer);
         getGeometryDeserializers().forEach(other::addDeserializer);
     }
-
 }

--- a/json/src/main/java/org/geolatte/geom/json/GeometryDeserializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/GeometryDeserializer.java
@@ -1,10 +1,5 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.GeometryType;
 import org.geolatte.geom.Position;
@@ -13,8 +8,11 @@ import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.geolatte.geom.crs.CoordinateReferenceSystems;
 import org.geolatte.geom.crs.CrsId;
 import org.geolatte.geom.crs.CrsRegistry;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -26,7 +24,7 @@ import static org.geolatte.geom.Geometries.mkGeometryCollection;
  * A Parser for Geometry types
  * Created by Karel Maesen, Geovise BVBA on 13/09/17.
  */
-public class GeometryDeserializer extends JsonDeserializer<Geometry<?>> {
+public class GeometryDeserializer extends ValueDeserializer<Geometry<?>> {
 
     private final CoordinateReferenceSystem<?> defaultCRS;
     private final Settings settings;
@@ -38,15 +36,12 @@ public class GeometryDeserializer extends JsonDeserializer<Geometry<?>> {
         this.crsDeser = new CrsDeserializer(this.defaultCRS, settings);
     }
 
-
-    private JsonNode getRoot(JsonParser p) throws IOException {
-        ObjectCodec oc = p.getCodec();
-        return oc.readTree(p);
+    private JsonNode getRoot(JsonParser p) {
+        return p.readValueAsTree();
     }
 
-
     @Override
-    public Geometry<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    public Geometry<?> deserialize(JsonParser p, DeserializationContext ctxt) {
         JsonNode root = getRoot(p);
         return parseGeometry(root);
     }
@@ -64,7 +59,6 @@ public class GeometryDeserializer extends JsonDeserializer<Geometry<?>> {
     protected CoordinateReferenceSystem<?> getDefaultCrs() {
         return defaultCRS;
     }
-
 
     private CoordinateReferenceSystem<?> resolveBaseCrs(JsonNode root) throws GeoJsonProcessingException {
         CrsId id = getCrsId(root);
@@ -103,9 +97,7 @@ abstract class GeometryBuilder {
             throw new GeoJsonProcessingException(String.format("Can't parse GeoJson of type %s", type));
         }
     }
-
 }
-
 
 class GeometryCollectionBuilder extends GeometryBuilder {
 
@@ -146,7 +138,6 @@ class GeometryCollectionBuilder extends GeometryBuilder {
         }
     }
 }
-
 
 class SimpleGeometryBuilder extends GeometryBuilder {
     final private GeometryType type;
@@ -243,6 +234,4 @@ class SimpleGeometryBuilder extends GeometryBuilder {
         }
         return holder;
     }
-
 }
-

--- a/json/src/main/java/org/geolatte/geom/json/GeometrySerializer.java
+++ b/json/src/main/java/org/geolatte/geom/json/GeometrySerializer.java
@@ -1,30 +1,26 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.core.type.WritableTypeId;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
 import org.geolatte.geom.*;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
-
-import java.io.IOException;
-import java.util.TimeZone;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.type.WritableTypeId;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.jsontype.TypeSerializer;
 
 import static org.geolatte.geom.GeometryType.*;
 
 /**
  * Created by Karel Maesen, Geovise BVBA on 09/09/17.
  */
-public class GeometrySerializer<P extends Position> extends JsonSerializer<Geometry<P>> {
+public class GeometrySerializer<P extends Position> extends ValueSerializer<Geometry<P>> {
 
     final private Settings settings;
 
     public GeometrySerializer(Settings settings) {
         this.settings = settings;
     }
-
 
     /**
      * Method that can be called to ask implementation to serialize
@@ -35,22 +31,22 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
      * @param serializers Provider that can be used to get serializers for
      */
     @Override
-    public void serialize(Geometry<P> geometry, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Geometry<P> geometry, JsonGenerator gen, SerializationContext serializers) {
         writeGeometry(gen, geometry, !settings.isSet(Setting.SUPPRESS_CRS_SERIALIZATION));
     }
 
     @Override
-    public void serializeWithType(Geometry<P> value, JsonGenerator gen, SerializerProvider serializers, TypeSerializer typeSer) throws IOException {
+    public void serializeWithType(Geometry<P> value, JsonGenerator gen, SerializationContext serializers, TypeSerializer typeSer) {
         // Better ensure we don't use specific sub-classes:
-        WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen,
+        WritableTypeId typeIdDef = typeSer.writeTypePrefix(gen, serializers,
                 typeSer.typeId(value, value.getClass(), JsonToken.VALUE_STRING));
         serialize(value, gen, serializers);
-        typeSer.writeTypeSuffix(gen, typeIdDef);
+        typeSer.writeTypeSuffix(gen, serializers, typeIdDef);
     }
 
-    private void writeGeometry(JsonGenerator gen, Geometry<P> geometry, boolean includeCrs) throws IOException {
+    private void writeGeometry(JsonGenerator gen, Geometry<P> geometry, boolean includeCrs) {
         gen.writeStartObject();
-        gen.writeStringField("type", geometry.getGeometryType().getCamelCased());
+        gen.writeStringProperty("type", geometry.getGeometryType().getCamelCased());
         if(includeCrs) {
             writeCrs(gen, geometry.getCoordinateReferenceSystem());
         }
@@ -63,8 +59,8 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndObject();
     }
 
-    private void writeGeometries(JsonGenerator gen, Geometry<P>[] geometries) throws IOException {
-        gen.writeFieldName("geometries");
+    private void writeGeometries(JsonGenerator gen, Geometry<P>[] geometries) {
+        gen.writeName("geometries");
         gen.writeStartArray();
         for(Geometry<P> g : geometries) {
             writeGeometry(gen, g, false);
@@ -72,8 +68,8 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndArray();
     }
 
-    private void writeCoords(JsonGenerator gen, GeometryType type, Geometry<P> geom) throws IOException {
-        gen.writeFieldName("coordinates");
+    private void writeCoords(JsonGenerator gen, GeometryType type, Geometry<P> geom) {
+        gen.writeName("coordinates");
         double[] buf = new double[geom.getCoordinateDimension()];
         if (geom.isEmpty()) {
             gen.writeStartArray();
@@ -94,7 +90,7 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         }
     }
 
-    private void writeListOfPolygon(JsonGenerator gen, MultiPolygon<P> geom, double[] buf) throws IOException {
+    private void writeListOfPolygon(JsonGenerator gen, MultiPolygon<P> geom, double[] buf) {
         gen.writeStartArray();
         for(Polygon<P> c : geom.components()) {
             writeListOfLinear(gen, c, buf);
@@ -102,7 +98,7 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndArray();
     }
 
-    private void writeListOfLinear(JsonGenerator gen, Complex geom, double[] buf) throws IOException {
+    private void writeListOfLinear(JsonGenerator gen, Complex geom, double[] buf) {
         gen.writeStartArray();
         for(Geometry<P> c : geom.components()) {
             writeLinear(gen, c, buf);
@@ -110,7 +106,7 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndArray();
     }
 
-    private void writeLinear(JsonGenerator gen, Geometry<P> geom, double[] buf) throws IOException {
+    private void writeLinear(JsonGenerator gen, Geometry<P> geom, double[] buf) {
         gen.writeStartArray();
 
         for (P pos : geom.getPositions()) {
@@ -119,20 +115,19 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndArray();
     }
 
-
-    private void writePosition(JsonGenerator gen, P position, double[] buf) throws IOException {
+    private void writePosition(JsonGenerator gen, P position, double[] buf) {
         gen.writeArray(position.toArray(buf), 0, buf.length);
     }
 
-    private void writeCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) throws IOException {
-        gen.writeFieldName("crs");
+    private void writeCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) {
+        gen.writeName("crs");
         writeNamedCrs(gen, crs);
     }
 
-    private void writeNamedCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) throws IOException {
+    private void writeNamedCrs(JsonGenerator gen, CoordinateReferenceSystem<P> crs) {
         gen.writeStartObject();
-        gen.writeStringField("type", "name");
-        gen.writeFieldName("properties");
+        gen.writeStringProperty("type", "name");
+        gen.writeName("properties");
         if (settings.isSet(Setting.SERIALIZE_CRS_AS_URN)) {
             writeCrsName(gen, crs.getCrsId().toUrn());
         } else {
@@ -141,11 +136,9 @@ public class GeometrySerializer<P extends Position> extends JsonSerializer<Geome
         gen.writeEndObject();
     }
 
-    private void writeCrsName(JsonGenerator gen, String epsgString) throws IOException {
+    private void writeCrsName(JsonGenerator gen, String epsgString) {
         gen.writeStartObject();
-        gen.writeStringField("name", epsgString);
+        gen.writeStringProperty("name", epsgString);
         gen.writeEndObject();
-
     }
-
 }

--- a/json/src/main/java/org/geolatte/geom/json/Setting.java
+++ b/json/src/main/java/org/geolatte/geom/json/Setting.java
@@ -47,6 +47,4 @@ public enum Setting {
     public boolean isSetByDefault() {
         return this.setByDefault;
     }
-
-
 }

--- a/json/src/main/java/org/geolatte/geom/json/Settings.java
+++ b/json/src/main/java/org/geolatte/geom/json/Settings.java
@@ -16,11 +16,9 @@ class Settings {
         return  override == null ? setting.isSetByDefault() : override;
     }
 
-
     public void override(Setting setting, boolean value) {
         if(setting.isSetByDefault() != value) {
             overrides.put(setting, value);
         }
     }
-
 }

--- a/json/src/test/java/org/geolatte/geom/json/CrsSupportTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/CrsSupportTest.java
@@ -1,8 +1,8 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -26,7 +26,6 @@ public class CrsSupportTest extends GeoJsonTest {
         assertEquals(crswgs84, mapper.writeValueAsString(WGS84));
         assertEquals(crslambert72, mapper.writeValueAsString(lambert72));
     }
-
 
     @Test
     public void testDeserializeCrs() throws IOException {

--- a/json/src/test/java/org/geolatte/geom/json/FeatureCollectionSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/FeatureCollectionSerializationTest.java
@@ -1,6 +1,5 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.FeatureCollection;
 
 import static org.geolatte.geom.builder.DSL.*;
@@ -9,6 +8,7 @@ import static org.geolatte.geom.json.GeoJsonStrings.*;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/json/src/test/java/org/geolatte/geom/json/FeatureSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/FeatureSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Feature;
 import org.geolatte.geom.Geometries;
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -41,8 +41,6 @@ public class FeatureSerializationTest extends GeoJsonTest {
         assertEquals(featureWithBBox, rec);
     }
 
-
-
     @Test
     public void testSerializeLineStringFeature() throws IOException {
         Map<Setting, Boolean> settingsMap = new HashMap<>();
@@ -74,4 +72,5 @@ public class FeatureSerializationTest extends GeoJsonTest {
         String rec = mapper.writeValueAsString(f);
         assertEquals(featureEmptyPolygon, rec);
     }
+
 }

--- a/json/src/test/java/org/geolatte/geom/json/ForceCrsToDefaultTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/ForceCrsToDefaultTest.java
@@ -1,10 +1,8 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.*;
-import org.geolatte.geom.crs.CoordinateReferenceSystem;
-import org.geolatte.geom.crs.LinearUnit;
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/json/src/test/java/org/geolatte/geom/json/GeoJsonTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/GeoJsonTest.java
@@ -1,9 +1,10 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Position;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.junit.Before;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.util.Map;
 
@@ -16,31 +17,38 @@ abstract public class GeoJsonTest {
 
     @Before
     public void setUp() {
-        mapper = new ObjectMapper();
-        mapper.registerModule(new GeolatteGeomModule());
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(new GeolatteGeomModule());
+        mapper = builder.build();
     }
 
     public ObjectMapper createMapper(Map<Setting, Boolean> features) {
         GeolatteGeomModule module = new GeolatteGeomModule();
         features.forEach((f, v) -> module.set(f, v));
-        mapper = new ObjectMapper();
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
         return mapper;
     }
 
     public ObjectMapper createMapper(Setting setting, boolean value) {
         GeolatteGeomModule module = new GeolatteGeomModule();
         module.set(setting, value);
-        mapper = new ObjectMapper();
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
         return mapper;
     }
 
     public <P extends Position> ObjectMapper createMapper(CoordinateReferenceSystem<P> crs, Setting f, boolean isSet) {
-        mapper = new ObjectMapper();
         GeolatteGeomModule module = new GeolatteGeomModule(crs);
         module.set(f, isSet);
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
         return mapper;
     }
 

--- a/json/src/test/java/org/geolatte/geom/json/GeometryCollectionSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/GeometryCollectionSerializationTest.java
@@ -1,10 +1,10 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.AbstractGeometryCollection;
 import org.geolatte.geom.GeometryCollection;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertEquals;
 public class GeometryCollectionSerializationTest extends GeoJsonTest {
 
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         GeometryCollection<?> geom = new GeometryCollection<>(WGS84);
         String rec = mapper.writeValueAsString(geom);
@@ -27,7 +27,7 @@ public class GeometryCollectionSerializationTest extends GeoJsonTest {
 
 
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         AbstractGeometryCollection<?, ?> geom = geometrycollection(
                 linestring(WGS84, g(1, 1), g(1, 2)),
@@ -38,7 +38,7 @@ public class GeometryCollectionSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCrs() throws JsonProcessingException {
+    public void testSerializeWithCrs() throws JacksonException {
         AbstractGeometryCollection<?, ?> geom = geometrycollection(
                 linestring(Crss.lambert72, c(1, 1), c(1, 2)),
                 point(Crss.lambert72, c(5, 6))
@@ -48,7 +48,7 @@ public class GeometryCollectionSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCrs3D() throws JsonProcessingException {
+    public void testSerializeWithCrs3D() throws JacksonException {
         AbstractGeometryCollection<?, ?> geom = geometrycollection(Crss.lambert72Z,
                 linestring(c(1, 1,1), c(1, 2,3)),
                 point(c(5, 6,7))

--- a/json/src/test/java/org/geolatte/geom/json/IgnoreCrsTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/IgnoreCrsTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Geometry;
 import org.geolatte.geom.Point;
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/json/src/test/java/org/geolatte/geom/json/LineStringDeserializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/LineStringDeserializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.LineString;
 
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 

--- a/json/src/test/java/org/geolatte/geom/json/LineStringSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/LineStringSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.LineString;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
@@ -18,8 +18,7 @@ public class LineStringSerializationTest extends GeoJsonTest {
 
 
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
-
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         LineString<?> ln = new LineString(WGS84);
         String rec = mapper.writeValueAsString(ln);
@@ -27,8 +26,7 @@ public class LineStringSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
-
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         LineString<?> ln = linestring(WGS84, g(1, 2), g(3, 4));
         String rec = mapper.writeValueAsString(ln);
@@ -36,7 +34,7 @@ public class LineStringSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCRS() throws JsonProcessingException {
+    public void testSerializeWithCRS() throws JacksonException {
         LineString<?> ln = linestring(Crss.lambert72, c(1, 2), c(3, 4));
         String rec = mapper.writeValueAsString(ln);
         assertEquals(lineStringWithCrs,rec) ;

--- a/json/src/test/java/org/geolatte/geom/json/MultiLineStringSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/MultiLineStringSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.MultiLineString;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
@@ -18,8 +18,7 @@ public class MultiLineStringSerializationTest extends GeoJsonTest {
 
 
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
-
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiLineString<?> mls = new MultiLineString(WGS84);
         String rec = mapper.writeValueAsString(mls);
@@ -27,7 +26,7 @@ public class MultiLineStringSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiLineString<?> mls = multilinestring(
                 linestring(WGS84, g(1, 1), g(1, 2)),
@@ -38,7 +37,7 @@ public class MultiLineStringSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCRS() throws JsonProcessingException {
+    public void testSerializeWithCRS() throws JacksonException {
         MultiLineString<?> mls = multilinestring(
                 linestring(Crss.lambert72, c(1, 1), c(1, 2)),
                 linestring(Crss.lambert72, c(3, 4), c(5, 6))

--- a/json/src/test/java/org/geolatte/geom/json/MultiPointSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/MultiPointSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.MultiPoint;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
@@ -16,10 +16,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class MultiPointSerializationTest extends GeoJsonTest {
 
-
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
-
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiPoint<?> mp = multipoint(WGS84);
         String rec = mapper.writeValueAsString(mp);
@@ -27,8 +25,7 @@ public class MultiPointSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
-
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiPoint<?> mp = multipoint(WGS84, g(1, 2), g(3, 4));
         String rec = mapper.writeValueAsString(mp);
@@ -36,11 +33,10 @@ public class MultiPointSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCRS() throws JsonProcessingException {
+    public void testSerializeWithCRS() throws JacksonException {
         MultiPoint<?> mp = multipoint(Crss.lambert72, c(1, 2), c(3, 4));
         String rec = mapper.writeValueAsString(mp);
         assertEquals(multiPointWithCrs, rec);
     }
-
 
 }

--- a/json/src/test/java/org/geolatte/geom/json/MultiPolygonSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/MultiPolygonSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.MultiPolygon;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.builder.DSL.polygon;
@@ -19,8 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class MultiPolygonSerializationTest extends GeoJsonTest {
 
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
-
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiPolygon<?> mp = multipolygon(WGS84);
         String rec = mapper.writeValueAsString(mp);
@@ -28,8 +27,7 @@ public class MultiPolygonSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
-
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         MultiPolygon<?> mp = multipolygon(
                 polygon(WGS84, ring(g(1, 1), g(1, 2), g(2, 2), g(2, 1), g(1, 1))),
@@ -40,7 +38,7 @@ public class MultiPolygonSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCRS() throws JsonProcessingException {
+    public void testSerializeWithCRS() throws JacksonException {
         MultiPolygon<?> mp =multipolygon(
                 polygon(lambert72, ring(c(1, 1), c(1, 2), c(2, 2), c(2, 1), c(1, 1))),
                 polygon(lambert72, ring(c(3, 3), c(3, 5), c(5, 5), c(5, 3), c(3, 3)))

--- a/json/src/test/java/org/geolatte/geom/json/PointDeserializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/PointDeserializationTest.java
@@ -1,11 +1,12 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.*;
 import org.geolatte.geom.crs.CoordinateReferenceSystem;
 import org.geolatte.geom.crs.Unit;
 import org.junit.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
@@ -19,9 +20,6 @@ import static org.junit.Assert.assertEquals;
  * Created by Karel Maesen, Geovise BVBA on 08/09/17.
  */
 public class PointDeserializationTest extends GeoJsonTest{
-
-
-
 
     @Test
     public void testDeserializePointText() throws IOException {
@@ -44,8 +42,11 @@ public class PointDeserializationTest extends GeoJsonTest{
     public void testDeserializePointTextWithSpecificCRS() throws IOException {
         TypeReference<Point<G2D>> typeRef = new TypeReference<Point<G2D>>() {
         };
-        mapper = new ObjectMapper();
-        mapper.registerModule(new GeolatteGeomModule(WGS84));
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(new GeolatteGeomModule(WGS84));
+        mapper = builder.build();
+
         Point<G2D> pnt = mapper.readValue(pointText, typeRef);
         Point<G2D> expected = point(WGS84, g(1, 2));
         assertEquals(expected, pnt);
@@ -76,11 +77,14 @@ public class PointDeserializationTest extends GeoJsonTest{
         assertEquals(expected, pnt);
     }
 
-
     @Test
     public void testDeserializePointTextWithNoLimitToCrs() throws IOException {
         GeolatteGeomModule module = new GeolatteGeomModule(wgs3D);
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
+
         Point<?> pnt = mapper.readValue(pointText, Point.class);
         Point<G2D> expected = point(WGS84, g(1, 2));
         assertEquals(expected, pnt);
@@ -88,10 +92,13 @@ public class PointDeserializationTest extends GeoJsonTest{
 
     @Test
     public void testDeserializePointTextWithLimitToCrs() throws IOException {
-        mapper = new ObjectMapper();
         GeolatteGeomModule module = new GeolatteGeomModule(wgs3D);
         module.set(Setting.IGNORE_CRS, true);
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
+
         Point<?> pnt = mapper.readValue(pointText, Point.class);
         Point<G3D> expected = point(wgs3D, g(1, 2, 0));
         assertEquals(expected, pnt);
@@ -99,10 +106,13 @@ public class PointDeserializationTest extends GeoJsonTest{
 
     @Test
     public void testDeserializePointTextWithLimitToCrsReduce() throws IOException {
-        mapper = new ObjectMapper();
         GeolatteGeomModule module = new GeolatteGeomModule(WGS84);
         module.set(Setting.IGNORE_CRS, true);
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
+
         Point<?> pnt = mapper.readValue(pointText3D, Point.class);
         Point<G2D> expected = point(WGS84, g(1, 2));
         assertEquals(expected, pnt);
@@ -111,11 +121,14 @@ public class PointDeserializationTest extends GeoJsonTest{
 
     @Test
     public void testDeserializePointTextWithLimitToCrs2DM() throws IOException {
-        mapper = new ObjectMapper();
         CoordinateReferenceSystem<G2DM> crs = WGS84.addLinearSystem(Unit.METER, G2DM.class);
         GeolatteGeomModule module = new GeolatteGeomModule(crs);
         module.set(Setting.IGNORE_CRS, true);
-        mapper.registerModule(module);
+
+        JsonMapper.Builder builder = JsonMapper.builder();
+        builder.addModule(module);
+        mapper = builder.build();
+
         Point<?> pnt = mapper.readValue(pointText2DM, Point.class);
         Point<G2DM> expected = point(crs, gM(1, 2, 4));
         assertEquals(expected, pnt);
@@ -144,7 +157,6 @@ public class PointDeserializationTest extends GeoJsonTest{
         Point<?> expected = point(wgs2DM, gM(1, 2, 3.0));
         assertEquals(expected, pnt);
     }
-
 
 }
 

--- a/json/src/test/java/org/geolatte/geom/json/PointSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/PointSerializationTest.java
@@ -1,9 +1,9 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Point;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.crs.CoordinateReferenceSystems.WGS84;
@@ -18,9 +18,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class PointSerializationTest extends GeoJsonTest {
 
-
     @Test
-    public void testSerializeEmptyPoint() throws JsonProcessingException {
+    public void testSerializeEmptyPoint() throws JacksonException {
         Point<?> pnt = new Point(WGS84);
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         String rec = mapper.writeValueAsString(pnt);
@@ -28,7 +27,7 @@ public class PointSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimplePoint() throws JsonProcessingException {
+    public void testSerializeSimplePoint() throws JacksonException {
         Point<?> pnt = point(WGS84, g(1, 2));
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         String rec = mapper.writeValueAsString(pnt);
@@ -36,7 +35,7 @@ public class PointSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeSimplePoint3D() throws JsonProcessingException {
+    public void testSerializeSimplePoint3D() throws JacksonException {
         Point<?> pnt = point(wgs3D, g(1, 2, 3));
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         String rec = mapper.writeValueAsString(pnt);
@@ -44,14 +43,10 @@ public class PointSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializePointWithCrs() throws JsonProcessingException {
+    public void testSerializePointWithCrs() throws JacksonException {
         Point<?> pnt = point(lambert72Z, c(1, 2, 3));
         String rec = mapper.writeValueAsString(pnt);
         assertEquals(GeoJsonStrings.pointTextWithCrs3D, rec);
     }
-
-
-
-
 
 }

--- a/json/src/test/java/org/geolatte/geom/json/PolygonDeserializerTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/PolygonDeserializerTest.java
@@ -24,7 +24,6 @@ public class PolygonDeserializerTest extends GeoJsonTest {
         assertEquals(exp, rec);
     }
 
-
     @Test
     public void testDeserializeSimple() throws IOException {
         Polygon<?> rec = mapper.readValue(polygon, Polygon.class);
@@ -38,6 +37,5 @@ public class PolygonDeserializerTest extends GeoJsonTest {
         Polygon<?> expected = polygon(Crss.lambert72, ring(c(1, 1), c(1, 2), c(2, 2), c(2, 1), c(1, 1)));
         assertEquals(expected, rec);
     }
-
 
 }

--- a/json/src/test/java/org/geolatte/geom/json/PolygonSerializationTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/PolygonSerializationTest.java
@@ -1,10 +1,10 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Geometries;
 import org.geolatte.geom.Polygon;
 import org.junit.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.geolatte.geom.builder.DSL.*;
 import static org.geolatte.geom.builder.DSL.polygon;
@@ -20,16 +20,15 @@ import static org.junit.Assert.assertEquals;
 public class PolygonSerializationTest extends GeoJsonTest {
 
     @Test
-    public void testSerializeEmpty() throws JsonProcessingException {
+    public void testSerializeEmpty() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         Polygon<?> p = Geometries.mkEmptyPolygon(WGS84);
         String rec = mapper.writeValueAsString(p);
         assertEquals(emptyPolygon, rec);
     }
 
-
     @Test
-    public void testSerializeSimple() throws JsonProcessingException {
+    public void testSerializeSimple() throws JacksonException {
         ObjectMapper mapper = createMapper(SUPPRESS_CRS_SERIALIZATION, true);
         Polygon<?> p = polygon(WGS84, ring(g(1, 1), g(1, 2), g(2, 2), g(2, 1), g(1, 1)));
         String rec = mapper.writeValueAsString(p);
@@ -37,7 +36,7 @@ public class PolygonSerializationTest extends GeoJsonTest {
     }
 
     @Test
-    public void testSerializeWithCrs() throws JsonProcessingException {
+    public void testSerializeWithCrs() throws JacksonException {
         Polygon<?> p = polygon(Crss.lambert72, ring(c(1, 1), c(1, 2), c(2, 2), c(2, 1), c(1, 1)));
         String rec = mapper.writeValueAsString(p);
         assertEquals(polygonWithCrs, rec);

--- a/json/src/test/java/org/geolatte/geom/json/UrnCrsSupportTest.java
+++ b/json/src/test/java/org/geolatte/geom/json/UrnCrsSupportTest.java
@@ -1,8 +1,8 @@
 package org.geolatte.geom.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.geolatte.geom.Point;
 import org.junit.Test;
+import tools.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 
@@ -19,7 +19,6 @@ public class UrnCrsSupportTest extends GeoJsonTest {
 
     @Test
     public void testSrializePointWithCrsInUrnFormat() throws IOException {
-
         ObjectMapper mapper = createMapper(Setting.SERIALIZE_CRS_AS_URN, true);
         Point<?> pnt = point(lambert72, c(1, 2));
         assertEquals(pointTextWithUrnCrs, mapper.writeValueAsString(pnt));


### PR DESCRIPTION
Changes only to the `json` module (`geolatte-geojson`).

Mostly changed the imports from `com.fasterxml.jackson` to `tools.jackson` and changed the implementation accordingly (lots of renamed method names, see https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0).

However one test case is currently failing: `testDeserializePointTextWithNoLimitToCrs()` fails because it converts the geometry to 3D (`wgs3D`) instead of keeping it 2D (`WGS84`):

```
Expected :SRID=4326;POINT(1 2)
Actual   :SRID=4326;POINT(1 2 0)
``` 

Unfortunately currently I'm not able to find the problem, any help is appreciated.

All other test cases work.