### PR TITLE
Switch to central-publishing-maven-plugin for publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,20 +127,19 @@
                         </executions>
                     </plugin>
 
-                    <!-- Sonatype release plugin -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.8</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <autoPublish>true</autoPublish>
+                            <publishingServerId>central</publishingServerId>
+                            <waitUntil>uploaded</waitUntil>
+                            <centralBaseUrl>https://central.sonatype.com</centralBaseUrl>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
-
-
                 </plugins>
             </build>
 
@@ -193,18 +192,6 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-
             <!-- see  https://maven.apache.org/maven-ci-friendly.html -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -234,18 +221,6 @@
 
         </plugins>
     </build>
-
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <repositories>
         <repository>


### PR DESCRIPTION
We've noticed that the build was still relying on the nexus plugin for releases, and since ossrh is "closed" and releases had to be switched to Maven Central publishing, here's a draft for that change. 
We weren't sure how exactly you release it as it seems there is no Github workflow, or some CI job ... 

(this is obviously not tested 🙂)

- see also: https://central.sonatype.org/publish/publish-portal-maven/